### PR TITLE
fixed typo

### DIFF
--- a/autoload/maktaba/string.vim
+++ b/autoload/maktaba/string.vim
@@ -37,7 +37,7 @@ endfunction
 
 
 ""
-" Returns {string} stripped of [chars] (a string of characters) from the front.
+" Returns {string} stripped of [chars] (a string of characters) from the end.
 " THE ORDER OF [chars] DOES NOT MATTER: stripping will continue so long as the
 " suffix contains one of [chars]. See also @function(#Strip).
 " @default chars=" \t\n\r"


### PR DESCRIPTION
Fixed simple typo, in the pre-generated documentation (hat tip: @chiphogg)

I've signed the CLA.
