### PR TITLE
Fix bug in rtp.vim causing undefined s:cache_string

### DIFF
--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -1,3 +1,5 @@
+let s:unescaped_comma = '\v\\@<!%(\\\\)*\zs,'
+let s:escaped_char = '\v\\([\,])'
 " Some users have local vimfiles in .vim, others in .config/vim.
 " Some distros install vim files into /usr/share/vimfiles, others in
 " /usr/share/vim/vimN where N is a version number (like /usr/share/vim/vim73).
@@ -6,9 +8,8 @@
 " So all paths whose final component matches the following regex are not
 " considered to be plugins.
 let s:leaf_pathcomponent = '\v^(\.vim|vim%(files)?\d*|after|runtime)$'
-let s:unescaped_comma = '\v\\@<!%(\\\\)*\zs,'
-let s:escaped_char = '\v\\([\,])'
-if !exists('s:leaf_pathcomponent')
+
+if !exists('s:cache_string')
   let s:cache_string = ''
   let s:cache_list = []
 endif


### PR DESCRIPTION
Fixes a bug from pull req #7 that prevents `s:cache_string` and `s:cache_list` from ever being defined.
