### PR TITLE
Add detection for plugins manually added to runtimepath

### DIFF
--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -991,7 +991,8 @@ maktaba#plugin#IsRegistered({plugin})            *maktaba#plugin#IsRegistered*
   1 if {plugin} was registered with maktaba#plugin#Register. This is more
   reliable for determining if a Maktaba compatible plugin by the name of
   {plugin} was registered, but can not be used to dependency check non-Maktaba
-  plugins.
+  plugins. Detects plugins added to 'runtimepath' even if they haven't been
+  explicitly registered with maktaba.
 
 maktaba#plugin#CanonicalName({plugin})          *maktaba#plugin#CanonicalName*
   The canonical name of {plugin}. This is the name of the plugin directory
@@ -1064,6 +1065,8 @@ maktaba#plugin#Get({plugin})                              *maktaba#plugin#Get*
   Gets the plugin object associated with {plugin}. {plugin} may either be the
   name of the plugin directory, or the canonicalized plugin name (with invalid
   characters converted to underscores). See |maktaba#plugin#CanonicalName|.
+  Detects plugins added to 'runtimepath' even if they haven't been explicitly
+  registered with maktaba.
   Throws ERROR(NotFound) if the plugin object does not exist.
 
 maktaba#plugin#GetOrInstall({dir}, [settings])   *maktaba#plugin#GetOrInstall*

--- a/vroom/libraries.vroom
+++ b/vroom/libraries.vroom
@@ -83,6 +83,16 @@ It worked! Huzzah. The 'library' plugin is installed.
 
   :call maktaba#ensure#IsTrue(maktaba#plugin#IsRegistered('library'))
 
+Dependencies can also be satisfied by plugins manually added to the runtimepath,
+even if they haven't been registered with maktaba yet.
+
+  :let g:tmpsource = tempname()
+  :call mkdir(g:tmpsource)
+  :let g:tmpplugin = maktaba#path#Join([g:tmpsource, 'tmpplugin'])
+  :call mkdir(g:tmpplugin)
+  :let &runtimepath .= ',' . g:tmpplugin
+  :call maktaba#ensure#IsTrue(maktaba#plugin#IsRegistered('tmpplugin'))
+
 Note that installers are only called the first time a plugin is installed. To
 see this, let's install a louder installer.
 

--- a/vroom/plugin.vroom
+++ b/vroom/plugin.vroom
@@ -180,6 +180,17 @@ loaded automatically. You can load it with the Load function:
 
 This will source all of the relevant plugin files.
 
+Maktaba is able to detect any plugin present on the runtimepath, even if it
+wasn't explicitly registered with maktaba.
+
+  :let g:fakeplugins = maktaba#path#Join([g:thisdir, 'fakeplugins'])
+  :let g:emptyplugin_path = maktaba#path#Join([g:fakeplugins, 'emptyplugin'])
+  :let &runtimepath .= ',' . g:emptyplugin_path
+  :call maktaba#ensure#IsTrue(maktaba#plugin#IsRegistered('emptyplugin'))
+  :let g:emptyplugin = maktaba#plugin#Get('emptyplugin')
+  :let g:emptyplugin_fullpath = maktaba#path#Join([g:emptyplugin_path, ''])
+  :call maktaba#ensure#IsEqual(g:emptyplugin.location, g:emptyplugin_fullpath)
+
 That's Maktaba plugin basics for you. There's still a lot more ground to cover.
 Here's a directory of relevant topics:
 


### PR DESCRIPTION
Updates `maktaba#plugin#Get()` and `maktaba#plugin#IsRegistered()` to find plugins manually added to runtimepath (and plugins installed by a plugin manager that doesn't integrate tightly with maktaba). Also affects the behavior of `maktaba#library#Import()` and `#library#Require()`.

Fixes #37.

I didn't do any special caching yet for `&rtp` paths like I mentioned in #37 because any performance regressions will be fairly limited: this code is only run when maktaba would have otherwise complained that the plugin was NotFound, or when `#plugin#IsRegistered()` would have returned 0. The caching will probably become more of an issue in implementing #38.
