### PR TITLE
Fix uncaught E716 by explicitly checking has_key(…, 'name')

### DIFF
--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -479,11 +479,12 @@ function! s:CreatePluginObject(name, location, settings) abort
   " Do this after creating the plugin dict so we can call AddonInfo and have
   " caching work.
   try
-    let l:plugin.name = s:SanitizedName(l:plugin.AddonInfo().name)
+    let l:addon_info = l:plugin.AddonInfo()
+    if has_key(l:addon_info, 'name')
+      let l:plugin.name = s:SanitizedName(l:addon_info.name)
+    endif
   catch /ERROR(BadValue):/
     " Couldn't deserialize JSON.
-  catch /E716:/
-    " No 'name' defined.
   endtry
   let s:plugins[l:plugin.name] = l:plugin
   let s:plugins_by_location[l:plugin.location] = l:plugin


### PR DESCRIPTION
Somehow vim ends up not catching the E716 in maktaba#plugin#Install and
letting it bubble up.
