### PR TITLE
Add "addons" to pattern of non-plugin dir names

### DIFF
--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -7,7 +7,7 @@ let s:escaped_char = '\v\\([\,])'
 " can contain an after/ directory.
 " So all paths whose final component matches the following regex are not
 " considered to be plugins.
-let s:leaf_pathcomponent = '\v^(\.vim|vim%(files)?\d*|after|runtime)$'
+let s:nonplugin_leaf = '\v^(\.vim|vim%(files)?\d*|after|runtime|addons)$'
 
 if !exists('s:cache_string')
   let s:cache_string = ''
@@ -136,7 +136,7 @@ function! maktaba#rtp#LeafDirs() abort
   for l:path in maktaba#rtp#Split(&runtimepath)
     let l:plugins[s:GetLeafDir(l:path)] = l:path
   endfor
-  return filter(l:plugins, 'v:key !~? s:leaf_pathcomponent')
+  return filter(l:plugins, 'v:key !~? s:nonplugin_leaf')
 endfunction
 
 


### PR DESCRIPTION
Ignores any directory called "addons" when scanning rtp for paths that look like plugin directories. This avoids the false positive of /var/lib/vim/addons/ showing up as a plugin on debian systems.

This means if you have a plugin called "addons" (shame on you!) maktaba will no longer correctly detect it. If we need to support that in the future, we could switch to a more clever heuristic like matching the full path.

Fixes #51.
