### PR TITLE
Fix ftplugin files not being entered in some buffers

### DIFF
--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -223,10 +223,10 @@ function! maktaba#plugin#Enter(file) abort
 
   if l:filedir ==# 'ftplugin'
     call extend(l:controller, {l:handle : []}, 'keep')
-    if index(l:controller[l:handle], bufnr('.')) >= 0
+    if index(l:controller[l:handle], bufnr('%')) >= 0
       return [l:plugin, 0]
     endif
-    call add(l:controller[l:handle], bufnr('.'))
+    call add(l:controller[l:handle], bufnr('%'))
     return [l:plugin, 1]
   endif
 

--- a/vroom/plugincontrol.vroom
+++ b/vroom/plugincontrol.vroom
@@ -88,13 +88,14 @@ possible after the plugin is activated.
 Similarly for ftplugin/ files, which are automatically activated by vim when it
 opens a buffer of the given filetype.
 
+  :edit! foo
   :let g:ftplugin_a = PluginPath(['ftplugin', 'a.vim'])
   :call maktaba#ensure#IsTrue(maktaba#plugin#Enter(g:ftplugin_a)[1])
   :call maktaba#ensure#IsFalse(maktaba#plugin#Enter(g:ftplugin_a)[1])
 
 However, these are tied to the buffer, and can be entered once per buffer.
 
-  :edit! foo
+  :edit! bar
   :call maktaba#ensure#IsTrue(maktaba#plugin#Enter(g:ftplugin_a)[1])
 
 Finally, we have autoload files. Vim sources these automatically as needed, and


### PR DESCRIPTION
Fixes `maktaba#plugin#Enter` to use `bufnr('%')` instead of `bufnr('.')` to get the correct number for the current buffer. The guard logic for ftplugin files was getting duplicate buffer numbers and sometimes preventing ftplugin files from being entered.

Fixes #75.
Also fixes test failures in plugincontrol.vroom.
