### PR TITLE
Fix rtp plugin detection to ignore .nvim as well as .vim

### DIFF
--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -1,13 +1,14 @@
 let s:unescaped_comma = '\v\\@<!%(\\\\)*\zs,'
 let s:escaped_char = '\v\\([\,])'
 " Some users have local vimfiles in .vim, others in .config/vim.
+" Neovim uses .nvim for local vimfiles.
 " Some distros install vim files into /usr/share/vimfiles, others in
 " /usr/share/vim/vimN where N is a version number (like /usr/share/vim/vim73).
 " Some users add runtime/ directories to their runtimepaths, and all plugins
 " can contain an after/ directory.
 " So all paths whose final component matches the following regex are not
 " considered to be plugins.
-let s:nonplugin_leaf = '\v^(\.vim|vim%(files)?\d*|after|runtime|addons)$'
+let s:nonplugin_leaf = '\v^(\.n?vim|vim%(files)?\d*|after|runtime|addons)$'
 
 if !exists('s:cache_string')
   let s:cache_string = ''


### PR DESCRIPTION
Neovim uses .nvim/ instead of .vim/ for local vimfiles, causing `maktaba#plugin#RegisteredPlugins` to consider '.nvim' as a plugin name and causing test failures in plugin.vroom and pluginutil.vroom when running vroom in neovim mode.

This changes plugin detection to ignore the .nvim/ dir.
