### PR TITLE
Don't change the current augroup when clearing.

### DIFF
--- a/autoload/maktaba/autocmd.vim
+++ b/autoload/maktaba/autocmd.vim
@@ -1,8 +1,6 @@
 
 "" Removes all autocmds in {augroup}, then removes {augroup}.
 function! maktaba#autocmd#ClearGroup(augroup) abort
-  execute 'augroup' a:augroup
-    autocmd!
-  augroup END
+  execute 'autocmd!' a:augroup
   execute 'augroup!' a:augroup
 endfunction


### PR DESCRIPTION
This prevents maktaba from changing the augroup to END (default) out
from under the user. This is probably an obscure corner case that we're
unlikely to ever actually see, but correctness is good.
