### PR TITLE
Improve argument validation for maktaba#buffer#Overwrite().

### DIFF
--- a/autoload/maktaba/buffer.vim
+++ b/autoload/maktaba/buffer.vim
@@ -29,6 +29,33 @@ function! maktaba#buffer#Overwrite(startline, endline, lines) abort
   call maktaba#ensure#IsNumber(a:endline)
   call maktaba#ensure#IsList(a:lines)
 
+  if a:startline < 1
+    throw maktaba#error#BadValue(
+        \ 'Startline must be positive, not %d.',
+        \ a:startline)
+  endif
+  if a:startline > line('$')
+    throw maktaba#error#BadValue(
+        \ 'Startline must be a valid line number, not %d.',
+        \ a:startline)
+  endif
+  if a:endline < 1
+    throw maktaba#error#BadValue(
+        \ 'Endline must be positive, not %d.',
+        \ a:endline)
+  endif
+  if a:endline > line('$')
+    throw maktaba#error#BadValue(
+        \ 'Endline must be a valid line number, not %d.',
+        \ a:endline)
+  endif
+  if a:startline > a:endline
+    throw maktaba#error#BadValue(
+        \ 'Startline %d greater than endline %d.',
+        \ a:startline,
+        \ a:endline)
+  endif
+
   " If python is available, use difflib-based python implementation, which can
   " overwrite only modified chunks and leave equal chunks undisturbed.
   if has('python')
@@ -41,12 +68,6 @@ function! maktaba#buffer#Overwrite(startline, endline, lines) abort
   endif
 
   " Otherwise, fall back to pure-vimscript implementation.
-  if a:startline > a:endline
-    throw maktaba#error#BadValue(
-        \ 'Startline %d greater than endline %d',
-        \ a:startline,
-        \ a:endline)
-  endif
   " If lines already match, don't modify buffer.
   if getline(a:startline, a:endline) == a:lines
     return

--- a/vroom/buffer.vroom
+++ b/vroom/buffer.vroom
@@ -81,6 +81,26 @@ matches the replacement text, nothing is changed:
   :echomsg b:changedtick == g:changedtick
   ~ 1
 
+Overwrite checks that the start and end lines are valid line numbers, and that
+the start line isn't after the end line:
+
+  :let g:overwrite = maktaba#function#Create('maktaba#buffer#Overwrite')
+  :call maktaba#error#Try(g:overwrite.WithArgs(0, 3, []))
+  ~ ERROR(BadValue): Startline must be positive, not 0.
+  :call maktaba#error#Try(g:overwrite.WithArgs(-1, 3, []))
+  ~ ERROR(BadValue): Startline must be positive, not -1.
+  :call maktaba#error#Try(g:overwrite.WithArgs(7, 8, []))
+  ~ ERROR(BadValue): Startline must be a valid line number, not 7.
+  :call maktaba#error#Try(g:overwrite.WithArgs(1, 0, []))
+  ~ ERROR(BadValue): Endline must be positive, not 0.
+  :call maktaba#error#Try(g:overwrite.WithArgs(6, 7, []))
+  ~ ERROR(BadValue): Endline must be a valid line number, not 7.
+  :call maktaba#error#Try(g:overwrite.WithArgs(6, 5, []))
+  ~ ERROR(BadValue): Startline 6 greater than endline 5.
+  :call maktaba#buffer#Overwrite(6, 6, [])
+  :echomsg line('$')
+  ~ 5
+
 
 
 Vim's :substitute (better known as :s) is one of its most powerful features.


### PR DESCRIPTION
- Check that 1 <= N <= line('$') for both startline and endline.
- Check that startline <= endline when using the Python implementation.
- Add tests for the above.

Fixes #82.
