### PR TITLE
Check g:weirdplugin.name in vroom, for clarity and nicer failures

### DIFF
--- a/vroom/pluginsignals.vroom
+++ b/vroom/pluginsignals.vroom
@@ -51,6 +51,8 @@ replace them with underscores.
   :let g:weirdpath = maktaba#path#Join([g:repo, 'weird¬p…l✓u↓g⏎i‽n'])
   :let g:weirdplugin = maktaba#plugin#Install(g:weirdpath)
 
+  :echomsg g:weirdplugin.name
+  ~ weird¬p…l✓u↓g⏎i‽n
   :call maktaba#ensure#IsTrue(g:installed_weird_p_l_u_g_i_n)
 
 In general, you should use maktaba#plugin#IsRegistered to check whether a plugin


### PR DESCRIPTION
Mainly I want this to demonstrate the remaining issue in google/vroom#76. The existing failure message just says `E121: Undefined variable: g:installed_weird_p_l_u_g_i_n`, but after this change it explains:

```
Unexpected message:
weird¬pâ<80>¦l✓u↓g⏎iâ<80>½n

Expected message not received:
"weird¬p…l✓u↓g⏎i‽n" (verbatim mode)
```
