### PR TITLE
Add a FLAG.AddCallback variant that doesn't fire immediately (#95)

### DIFF
--- a/autoload/maktaba/flags.vim
+++ b/autoload/maktaba/flags.vim
@@ -115,21 +115,29 @@ endfunction
 
 ""
 " @dict Flag
-" @usage callback
 " Registers {callback}. It must refer to a function. The function must take one
-" argument: the value of the flag. {callback} will be fired immediately with the
-" current value of the flag. It will be fired again every time the flag changes.
+" argument: the value of the flag. {callback} will (by default) be fired
+" immediately with the current value of the flag. It will be fired again every
+" time the flag changes.
 "
 " Callbacks are fired AFTER translation occurs. Callbacks are fired in order of
 " their registration.
 "
 " This function returns a function which, when applied, unregisters {callback}.
 " Hold on to it if you expect you'll need to remove {callback}.
+"
+" If [fire_immediately] is zero, {callback} will only be fired when the
+" current value of the flag changes.
+" @default fire_immediately=1
 " @throws BadValue if there's already a callback registered under that name.
-function! maktaba#flags#AddCallback(F) dict abort
+function! maktaba#flags#AddCallback(F, ...) dict abort
   call maktaba#ensure#IsCallable(a:F)
+  let l:fire_immediately = get(a:, 1, 1)
+
   let l:remover = self._callbacks.Add(a:F)
-  call maktaba#function#Apply(a:F, self._value)
+  if l:fire_immediately
+    call maktaba#function#Apply(a:F, self._value)
+  endif
   return l:remover
 endfunction
 

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -117,17 +117,21 @@ Flag.Set({value}, [foci])                                         *Flag.Set()*
   will set value['a'][0]['b'] to 'leaf'.
   Throws ERROR(BadValue) when an invalid focus is requested.
 
-Flag.AddCallback({callback})                              *Flag.AddCallback()*
+Flag.AddCallback({callback}, [fire_immediately])          *Flag.AddCallback()*
   Registers {callback}. It must refer to a function. The function must take
-  one argument: the value of the flag. {callback} will be fired immediately
-  with the current value of the flag. It will be fired again every time the
-  flag changes.
+  one argument: the value of the flag. {callback} will (by default) be fired
+  immediately with the current value of the flag. It will be fired again every
+  time the flag changes.
 
   Callbacks are fired AFTER translation occurs. Callbacks are fired in order
   of their registration.
 
   This function returns a function which, when applied, unregisters
   {callback}. Hold on to it if you expect you'll need to remove {callback}.
+
+  If [fire_immediately] is zero, {callback} will only be fired when the
+  current value of the flag changes.
+  [fire_immediately] is 1 if omitted.
   Throws ERROR(BadValue) if there's already a callback registered under that
   name.
 

--- a/vroom/flags.vroom
+++ b/vroom/flags.vroom
@@ -107,12 +107,27 @@ thereafter.
   ~ HEY THE VALUE IS 3
   ~ FIRST! Wait...
 
+The fire-when-attached behavior can also be suppressed by setting the
+fire_immediately parameter to zero. This is useful if your callback should only
+fire when a value is changed from the current value.
+
+  :function! Changed(value) abort
+  :  echomsg 'Changed!'
+  :endfunction
+  :call g:full.AddCallback('Changed', 0)
+
+  :call g:full.Set(1)
+  ~ HEY THE VALUE IS 1
+  ~ FIRST! Wait...
+  ~ Changed!
+
 You may have noticed that AddCallback returns a function. This function can be
 used to remove a registered callback:
 
   :call maktaba#function#Apply(g:rmsecond)
   :call g:full.Set(4)
   ~ HEY THE VALUE IS 4
+  ~ Changed!
 
 
 


### PR DESCRIPTION
Adds an optional `fire_immediately` parameter to `Flag.AddCallback` to allow the initial call to be suppressed.

Also fixed some spelling mistakes in the Vroom test comments, and regenerated the documentation.
