### PR TITLE
Batch cleanup typos

### DIFF
--- a/autoload/maktaba.vim
+++ b/autoload/maktaba.vim
@@ -14,7 +14,7 @@
 " recommends users install a configuration plugin like |Glaive|, or a plugin
 " manager with configuration support, to manage plugin flags.
 "
-" Also included are a univesal logging framework, error handling utilities, and
+" Also included are a universal logging framework, error handling utilities, and
 " a number of tools that make writing vimscript both safer and easier.
 
 

--- a/autoload/maktaba/ensure.vim
+++ b/autoload/maktaba/ensure.vim
@@ -181,8 +181,8 @@ endfunction
 ""
 " Ensures that {value} is callable (string or funcref). Returns it for
 " convenience.  This DOES NOT assert that the function denoted by {value}
-" actually exists. It mereley ensures that {value} is the correct TYPE for
-" |maktaba#function#Call|.
+" actually exists. It merely ensures that {value} is the correct TYPE for
+" @function(maktaba#function#Call).
 " @throws WrongType if {value} is not a string, funcref, nor dict.
 " @throws BadValue if {value} is a dict but does not appear to be a funcdict.
 function! maktaba#ensure#IsCallable(Value) abort

--- a/autoload/maktaba/error.vim
+++ b/autoload/maktaba/error.vim
@@ -75,7 +75,7 @@ endfunction
 ""
 " Prints {message} in an angry red error bar for the user.
 " Don't use |:echoerr|! It doesn't make that red error bar and it prints out the
-" line in the code where the error occured. It's for debugging, not messaging!
+" line in the code where the error occurred. It's for debugging, not messaging!
 " If [args...] are given they will be used to expand {message} as in |printf()|.
 function! maktaba#error#Shout(message, ...) abort
   call call('s:EchoHighlighted', ['ErrorMsg', a:message] + a:000)

--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -701,7 +701,7 @@ endfunction
 ""
 " @dict Plugin
 " Tests whether the plugin has {dir}, either as a direct subdirectory or as
-" a subirectory of the after/ directory.
+" a subdirectory of the after/ directory.
 " Cached for performance, so new paths will not be discovered if they're added
 " to the plugin after the first check.
 function! maktaba#plugin#HasDir(dir) dict abort
@@ -713,7 +713,7 @@ endfunction
 
 ""
 " @dict Plugin
-" Tests wheter a plugin has a filetype-active directory (ftdetect, ftplugin,
+" Tests whether a plugin has a filetype-active directory (ftdetect, ftplugin,
 " indent, or syntax).
 function! maktaba#plugin#HasFiletypeData() dict abort
   return maktaba#rtp#DirDefinesFiletypes(self.location)

--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -70,7 +70,7 @@ endfunction
 " Trailing slashes will be stripped, following the precedent of vim itself not
 " including trailing slashes. This is also safer since trailing backslashes on
 " Windows are a source of bugs, and it doesn't lead to ambiguity since all paths
-" should be dirs. Note that @function(#Split) converts paths back to canoncial
+" should be dirs. Note that @function(#Split) converts paths back to canonical
 " representation, with trailing slashes included.
 function! maktaba#rtp#Join(paths) abort
   call maktaba#ensure#IsList(a:paths)

--- a/autoload/maktaba/setting.vim
+++ b/autoload/maktaba/setting.vim
@@ -1,4 +1,4 @@
-" NOTE: Variables in this regex that start with captial letters may be funcrefs.
+" NOTE: Variables in this regex that start with capital letters may be funcrefs.
 " DO NOT change them to start with lowercase letters.
 
 " Parser regexes.
@@ -40,7 +40,7 @@ let s:leadingwhite = '\v^\s+'
 " * -= subtracts from numbers and removes from lists and dictionaries.
 " * ^= prepends to lists and strings.
 " * $= appends to lists and strings.
-" * `= sets a flag to the result of appling the function named by the value.
+" * `= sets a flag to the result of applying the function named by the value.
 "
 " Values are parsed as follows:
 " 1. Values in single or double quotes are parsed as strings.
@@ -141,7 +141,7 @@ endfunction
 " for convenience.
 " @throws NotFound if {plugin} does not define the appropriate flag.
 " @throws WrongType if the flag is not of a type the setting requires.
-" @throws BadValue if the flag has a value innapropriate for the setting.
+" @throws BadValue if the flag has a value inappropriate for the setting.
 function! maktaba#setting#Apply(plugin) dict abort
   let l:flag = self._GetFlag(a:plugin)
   try
@@ -204,7 +204,7 @@ function! maktaba#setting#AddTo(flag) dict abort
     return
   endif
   if maktaba#value#IsNumeric(l:Target)
-    " Floats and integers can be added indiscriminantly.
+    " Floats and integers can be added indiscriminately.
     call maktaba#ensure#IsNumeric(self._value)
   else
     " Everything else must be added to something of the same type.
@@ -514,11 +514,11 @@ endfunction
 " <
 " More specifically, this parses a flag name and a series of foci in square
 " brackets. A flag name may contain alphanumeric characters and underscores.
-" Flag names may also contain, BUT NOT END WITH, the following charcaters:
+" Flag names may also contain, BUT NOT END WITH, the following characters:
 " - . / : #
 "
 " Foci are kept in square brackets. They are not allowed to contain square
-" brackets. They should describe either dictionary keys or list indicies.
+" brackets. They should describe either dictionary keys or list indices.
 "
 " You're encouraged to use this function when you're exposing complex flags to
 " users. Flag handles are part of the maktaba setting syntax. See

--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -5,7 +5,6 @@ if !exists('s:usable_shell')
 endif
 
 
-" TODO(jhoak): correctly handle <cword>, <cfile>, etc.,
 ""
 " Escape the special chars in a {string}.  This is useful for when "execute
 " '!foo'" is used. The \ is then removed again by the :! command.  See helpdocs

--- a/autoload/maktaba/test.vim
+++ b/autoload/maktaba/test.vim
@@ -1,4 +1,4 @@
-" Copied from maktaba/path.vim, which Overide may not depend upon.
+" Copied from maktaba/path.vim, which Override may not depend upon.
 let s:is_windows = exists('+shellslash')
 let s:use_backslash = s:is_windows && !&shellslash
 let s:slash = s:use_backslash ? '\' : '/'
@@ -24,7 +24,7 @@ let s:apply_function_lines = [
 
 
 ""
-" Overides the function {target} such that when it is called, {replacement} is
+" Overrides the function {target} such that when it is called, {replacement} is
 " called instead. This is particularly useful for overloading autoloaded
 " functions, which can only be done in files that are named correctly.
 " (name#spaced#Function must be defined in .../name/spaced.vim).

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -23,7 +23,7 @@ Maktaba introduces a concept of a |maktaba.Flag| for configuration, and
 recommends users install a configuration plugin like |Glaive|, or a plugin
 manager with configuration support, to manage plugin flags.
 
-Also included are a univesal logging framework, error handling utilities, and
+Also included are a universal logging framework, error handling utilities, and
 a number of tools that make writing vimscript both safer and easier.
 
 ==============================================================================
@@ -132,8 +132,6 @@ Flag.AddCallback({callback}, [fire_immediately])          *Flag.AddCallback()*
   If [fire_immediately] is zero, {callback} will only be fired when the
   current value of the flag changes.
   [fire_immediately] is 1 if omitted.
-  Throws ERROR(BadValue) if there's already a callback registered under that
-  name.
 
 Flag.Callback()                                              *Flag.Callback()*
   Fires all callbacks in order.
@@ -151,8 +149,6 @@ Flag.AddTranslator({translator})                        *Flag.AddTranslator()*
   This function returns a function which, when called, unregisters
   {translator}. Hold on to it if you expect you'll need to remove
   {translator}.
-  Throws ERROR(BadValue) if there's already a translator registered under that
-  name.
 
 Flag.Translate({value})                                     *Flag.Translate()*
   Returns the value that the flag will have after being set to {value} (after
@@ -195,11 +191,11 @@ Plugin.GenerateHelpTags()                          *Plugin.GenerateHelpTags()*
 
 Plugin.HasDir({dir})                                         *Plugin.HasDir()*
   Tests whether the plugin has {dir}, either as a direct subdirectory or as a
-  subirectory of the after/ directory. Cached for performance, so new paths
+  subdirectory of the after/ directory. Cached for performance, so new paths
   will not be discovered if they're added to the plugin after the first check.
 
 Plugin.HasFiletypeData()                            *Plugin.HasFiletypeData()*
-  Tests wheter a plugin has a filetype-active directory (ftdetect, ftplugin,
+  Tests whether a plugin has a filetype-active directory (ftdetect, ftplugin,
   indent, or syntax).
 
 Plugin.AddonInfo()                                        *Plugin.AddonInfo()*
@@ -302,7 +298,7 @@ Valid binary operators are = += -= ^= $= and `=.
   * -= subtracts from numbers and removes from lists and dictionaries.
   * ^= prepends to lists and strings.
   * $= appends to lists and strings.
-  * `= sets a flag to the result of appling the function named by the value.
+  * `= sets a flag to the result of applying the function named by the value.
 
 Values are parsed as follows:
   1. Values in single or double quotes are parsed as strings.
@@ -323,7 +319,7 @@ Setting.Apply({plugin})                                      *Setting.Apply()*
   for convenience.
   Throws ERROR(NotFound) if {plugin} does not define the appropriate flag.
   Throws ERROR(WrongType) if the flag is not of a type the setting requires.
-  Throws ERROR(BadValue) if the flag has a value innapropriate for the
+  Throws ERROR(BadValue) if the flag has a value inappropriate for the
   setting.
 
                                                              *maktaba.Syscall*
@@ -544,8 +540,8 @@ maktaba#ensure#IsCollection({value})           *maktaba#ensure#IsCollection()*
 maktaba#ensure#IsCallable({value})               *maktaba#ensure#IsCallable()*
   Ensures that {value} is callable (string or funcref). Returns it for
   convenience.  This DOES NOT assert that the function denoted by {value}
-  actually exists. It mereley ensures that {value} is the correct TYPE for
-  |maktaba#function#Call|.
+  actually exists. It merely ensures that {value} is the correct TYPE for
+  |maktaba#function#Call()|.
   Throws ERROR(WrongType) if {value} is not a string, funcref, nor dict.
   Throws ERROR(BadValue) if {value} is a dict but does not appear to be a
   funcdict.
@@ -617,7 +613,7 @@ maktaba#error#Warn({message}, [args...])                *maktaba#error#Warn()*
 maktaba#error#Shout({message}, [args...])              *maktaba#error#Shout()*
   Prints {message} in an angry red error bar for the user. Don't use
   |:echoerr|! It doesn't make that red error bar and it prints out the line in
-  the code where the error occured. It's for debugging, not messaging! If
+  the code where the error occurred. It's for debugging, not messaging! If
   [args...] are given they will be used to expand {message} as in |printf()|.
 
 maktaba#error#Exception({type}, {message}, {fmtargs})
@@ -1020,8 +1016,8 @@ maktaba#path#Basename({path})                        *maktaba#path#Basename()*
 maktaba#path#Dirname({path})                          *maktaba#path#Dirname()*
   The dirname of {path}. Trailing slash matters. Consider:
 >
-    :echomsg maktaba#path#Basename('/path/to/file')
-    :echomsg maktaba#path#Basename('/path/to/dir/')
+    :echomsg maktaba#path#Dirname('/path/to/file')
+    :echomsg maktaba#path#Dirname('/path/to/dir/')
 <
   The first echoes '/path/to', the second echoes '/path/to/dir'
 
@@ -1223,7 +1219,7 @@ maktaba#rtp#Join({paths})                                 *maktaba#rtp#Join()*
   including trailing slashes. This is also safer since trailing backslashes on
   Windows are a source of bugs, and it doesn't lead to ambiguity since all
   paths should be dirs. Note that |maktaba#rtp#Split()| converts paths back to
-  canoncial representation, with trailing slashes included.
+  canonical representation, with trailing slashes included.
 
 maktaba#rtp#Add({path})                                    *maktaba#rtp#Add()*
   Adds {path} to the runtimepath.
@@ -1314,11 +1310,11 @@ maktaba#setting#Handle({handle})                    *maktaba#setting#Handle()*
 <
   More specifically, this parses a flag name and a series of foci in square
   brackets. A flag name may contain alphanumeric characters and underscores.
-  Flag names may also contain, BUT NOT END WITH, the following charcaters:
+  Flag names may also contain, BUT NOT END WITH, the following characters:
   . / : #
 
   Foci are kept in square brackets. They are not allowed to contain square
-  brackets. They should describe either dictionary keys or list indicies.
+  brackets. They should describe either dictionary keys or list indices.
 
   You're encouraged to use this function when you're exposing complex flags to
   users. Flag handles are part of the maktaba setting syntax. See
@@ -1382,8 +1378,8 @@ maktaba#syscall#Create({cmd})                       *maktaba#syscall#Create()*
   Throws ERROR(WrongType)
 
 maktaba#test#Override({target}, {replacement})       *maktaba#test#Override()*
-  Overides the function {target} such that when it is called, {replacement} is
-  called instead. This is particularly useful for overloading autoloaded
+  Overrides the function {target} such that when it is called, {replacement}
+  is called instead. This is particularly useful for overloading autoloaded
   functions, which can only be done in files that are named correctly.
   (name#spaced#Function must be defined in .../name/spaced.vim).
 

--- a/examples/helloworld/doc/helloworld.txt
+++ b/examples/helloworld/doc/helloworld.txt
@@ -26,6 +26,11 @@ flag that can be configured using |Glaive| or a plugin manager that uses the
 maktaba setting API. It also supports entirely disabling commands from being
 defined by clearing the plugin[commands] flag.
 
+                                                             *helloworld:name*
+Determines who the greeting will be addressed to when |:Hello| is executed
+without an explicit name argument.
+Default: 'world' `
+
                                                  *helloworld:plugin[commands]*
 Configures whether plugin/commands.vim should be loaded.
 Default: 1 `
@@ -33,11 +38,6 @@ Default: 1 `
                                                  *helloworld:plugin[mappings]*
 Configures whether plugin/mappings.vim should be loaded.
 Default: 0 `
-
-                                                             *helloworld:name*
-Determines who the greeting will be addressed to when |:Hello| is executed
-without an explicit name argument.
-Default: 'world' `
 
 ==============================================================================
 COMMANDS                                                 *helloworld-commands*

--- a/vroom/ensure.vroom
+++ b/vroom/ensure.vroom
@@ -91,7 +91,7 @@ This is not recommended, but is often convenient when writing tests.
 
 
 
-You can also make assertions about the type of a value, analagously to
+You can also make assertions about the type of a value, analogously to
 maktaba#value:
 
   :call maktaba#ensure#TypeMatches(100, 0)

--- a/vroom/error.vroom
+++ b/vroom/error.vroom
@@ -113,7 +113,7 @@ piping varargs around.
 
 Sometimes it is necessary to deconstruct an error message into the type and the
 message. This is especially useful when you want to catch an error, attach
-additional context, and re-throw it. Note that it's usually preferrable to wrap
+additional context, and re-throw it. Note that it's usually preferable to wrap
 errors, but sometimes destructuring an exception can really clean up your
 messages. maktaba#error#Split is there when you need it.
 

--- a/vroom/ftplugin.vroom
+++ b/vroom/ftplugin.vroom
@@ -38,9 +38,9 @@ have not been noticed. If we edit a .newtype file, nothing happens:
   :e file.newtype
   @messages
 
-We have to load filetype files in a separate phase. Why doesn't the Load funtion
-handle this automatically? The answer is somewhat technical: loading new
-filetypes involves wiping out all filetype detection (and all syntax
+We have to load filetype files in a separate phase. Why doesn't the Load
+function handle this automatically? The answer is somewhat technical: loading
+new filetypes involves wiping out all filetype detection (and all syntax
 highlighting, and all indent code, and so on) and reloading EVERYTHING from
 scratch. This is just the way vim does things: it's a very global operation. If
 you're loading a whole bunch of plugins then you only want to reload filetype

--- a/vroom/function.vroom
+++ b/vroom/function.vroom
@@ -32,7 +32,7 @@ dictionary context (for dictionary functions).
 
 If you happen to know that you're holding a maktaba function object (and not
 some other callable, such as a funcref or a string naming a function) you can
-apply the funtion using the attached "apply" method.
+apply the function using the attached "apply" method.
 
   :echomsg g:getter.Apply('one')
   ~ alpha
@@ -41,7 +41,7 @@ apply the funtion using the attached "apply" method.
 
 Normally, though, you can't know whether you're dealing with a maktaba function
 dictionary, a vimscript funcref, or a simple string naming a function. When
-that's the case, you can use the makatab#function#Call function which works
+that's the case, you can use the maktaba#function#Call function which works
 with any of the above.
 
   :echomsg maktaba#function#Call(g:getter, ['three'])
@@ -80,7 +80,7 @@ Sometimes you want to use dict functions:
   :echomsg g:getone.Apply()
   ~ alpha
 
-It's also worth noting that, if a function requries no arguments, you can leave
+It's also worth noting that, if a function requires no arguments, you can leave
 the arglist off of #Apply entirely.
 
   :echomsg maktaba#function#Call(g:getone)

--- a/vroom/list.vroom
+++ b/vroom/list.vroom
@@ -12,7 +12,7 @@ will be modified.
 
 
 For example, here's the maktaba#list#RemoveItem function, which removes the
-first occurance of an item from a list.
+first occurrence of an item from a list.
 
   :let g:list = [3, 1, 2, 1]
   :call maktaba#list#RemoveItem(g:list, 1)
@@ -32,7 +32,7 @@ The modified list is returned for convenience.
 
 
 
-The maktaba#list#RemoveAll function is similar, but removes all occurrances of
+The maktaba#list#RemoveAll function is similar, but removes all occurrences of
 an item in the list.
 
   :let g:list = [3, 1, 2, 1]

--- a/vroom/manual.vroom
+++ b/vroom/manual.vroom
@@ -7,7 +7,7 @@ that maktaba plugin files will run when vim setup is complete.
 
 Second, it checks that vi-compatibility mode is OFF. Maktaba is does not support
 vi-compatibility mode! If you're installing maktaba manually, make sure you turn
-off vi comatibility. The maktaba#CheckCompatibility function will do this for
+off vi compatibility. The maktaba#CheckCompatibility function will do this for
 you, and will print a nice warning message if you were in the wrong mode.
 
   :call maktaba#compatibility#Disable()

--- a/vroom/mappings.vroom
+++ b/vroom/mappings.vroom
@@ -41,7 +41,7 @@ sanitary:
 |  <Plug> is a map sequence that cannot be typed, but which can be mapped to. If
 |  you have complicated key mappings that are hard to replicate, but you don't
 |  know what keys the user wants to map them to, then you should use <Plug> to
-|  make the mappings avialable WITHOUT actually changing the user's mappings.
+|  make the mappings available WITHOUT actually changing the user's mappings.
 |  For example:
 |
 |    :noremap <unique> <Plug>myplugin-stutter 6j5k4j3k2j1k
@@ -59,7 +59,7 @@ sanitary:
 
 3. If you really must define key mappings, then you should place them all under
 |  a SINGLE LETTER underneath the user's chosen mapleader. For example, if you
-|  are writting a sorting plugin, you should consider placing all mappings under
+|  are writing a sorting plugin, you should consider placing all mappings under
 |  <leader>s: <leader>su to sort up, <leader>sd to sort down, and so on. This at
 |  least limits the amount of damage you can do to the user's existing mappings.
 |  Ideally, you should do this in a way that's configurable by the user.

--- a/vroom/path.vroom
+++ b/vroom/path.vroom
@@ -1,5 +1,5 @@
 Maktaba has some utilities that help you deal with system paths in
-a machine-independant way. Mostly, this involves manipulating filepaths and
+a machine-independent way. Mostly, this involves manipulating filepaths and
 figuring out which directions the slashes go. This is nontrivial in vim thanks
 to the 'shellslash' setting (which allows windows users to use unix-style
 slashes).

--- a/vroom/plugin.vroom
+++ b/vroom/plugin.vroom
@@ -161,7 +161,7 @@ maktaba#plugin#Get to get another:
   :call maktaba#ensure#IsEqual(maktaba#plugin#Get('myplugin'), g:plugin)
 
 This all works as you might expect, but none of it is very interesting. Let's
-see what the plugin object can do. It posesses some boring data, such as name
+see what the plugin object can do. It possesses some boring data, such as name
 and location:
 
   :echomsg g:plugin.name

--- a/vroom/pluginflags.vroom
+++ b/vroom/pluginflags.vroom
@@ -121,5 +121,5 @@ used on all the various levels:
 |  instant/flags.vim file.
 2. Plugin code should access flags via the Flag function. In general, plugins
 |  should not set their own flags: they should set defaults and leave them be.
-3. Users change the values of flags, generaly by interacting with commands
+3. Users change the values of flags, generally by interacting with commands
 |  in plugins like Glaive, which put a user frontend on the maktaba flags API.

--- a/vroom/pluginsignals.vroom
+++ b/vroom/pluginsignals.vroom
@@ -39,7 +39,7 @@ is on the runtimepath) and plugin LOADING (when the plugin files are sourced).
 For example, autoloaded functions are available after installation, before any
 plugin has time to set their g:loaded_* variable.
 
-Maktaba works aroud this issue by setting a different global variable,
+Maktaba works around this issue by setting a different global variable,
 g:installed_{plugin}, signaling that the plugin is installed (but perhaps not
 yet loaded).
 

--- a/vroom/pluginutil.vroom
+++ b/vroom/pluginutil.vroom
@@ -88,7 +88,7 @@ one more plugin:
   :let g:ftpath = maktaba#path#Join([g:repo, 'ftplugin'])
   :let g:ftplugin = maktaba#plugin#Install(g:ftpath)
 
-Each plugin has a HasDir funtion which lets you know if a plugin has a specific
+Each plugin has a HasDir function which lets you know if a plugin has a specific
 directory, either as a direct subdirectory or in an after/ directory. You might
 want to verify the following statements in the plugins in the fakeplugin
 directory.

--- a/vroom/setting.vroom
+++ b/vroom/setting.vroom
@@ -1,5 +1,5 @@
 Global plugin settings are a soul-rending, albeit heretofore necessary, evil.
-They're global, for one thing: you've got to remeber to confine them to ad-hoc
+They're global, for one thing: you've got to remember to confine them to ad-hoc
 namespaces. There's no way to enforce consistency in naming: Sooner or later you
 have to set g:SomePluginsCamelCasedSetting, g:inconsistent_under_scores,
 g:too_trse, or g:settings_named_such_that_they_barely_fit_on_one_line.
@@ -18,7 +18,7 @@ variable, right? Well, no. See, your code lives in a plugin/ directory
 somewhere, and the user configures your plugin via their .vimrc file, and their
 vimrc runs before your global setting is defined. They can *override* your list,
 but they cannot extend it. Global settings are hobbled. This makes it difficult
-for plugin authors to provide robust defaults for complex configuraitons, and
+for plugin authors to provide robust defaults for complex configurations, and
 frustrating for users who just want to tweak the defaults.
 
 Last but not least, global settings are opaque to both developers and users.
@@ -173,7 +173,7 @@ setting and the remainder of the string.
 
 
 
-As a shorcut, you can also use maktaba#setting#ParseAll to parse an entire
+As a shortcut, you can also use maktaba#setting#ParseAll to parse an entire
 whitespace-separated string of settings at once.
 
   :let [g:inc, g:dec] = maktaba#setting#ParseAll('number+=1 number-=1')
@@ -258,7 +258,7 @@ REGARDLESS of the original type of the flag. Observe:
   :call Is(1, Apply('dict'))
   :call Is(1, Apply('function'))
 
-They're all numbers now, despite their names and their orignial types.
+They're all numbers now, despite their names and their original types.
 
 
 
@@ -276,7 +276,7 @@ original type of the flag. Observe:
   :call Is(0, Apply('!dict'))
   :call Is(0, Apply('!function'))
 
-They're all numbers now, despite their names and their orignial types.
+They're all numbers now, despite their names and their original types.
 
 
 


### PR DESCRIPTION
I just enabled spell checking in vim, so I decided to take it for a spin through the maktaba project to get a baseline wordlist and fixed all the typos I found along the way.
