### PR TITLE
Change 'details' link to point to the wiki.

### DIFF
--- a/examples/helloworld/instant/flags.vim
+++ b/examples/helloworld/instant/flags.vim
@@ -3,7 +3,8 @@
 " the maktaba#setting API. Maktaba will make sure this file is sourced
 " immediately when the plugin is installed so that flags are defined and
 " initialized to their default values before users configure them. See
-" go/write-maktaba-plugin for details.
+" https://github.com/google/vim-maktaba/wiki/Creating-Vim-Plugins-with-Maktaba
+" for details.
 
 ""
 " @section Introduction, intro


### PR DESCRIPTION
Change the link to details on creating Maktaba plugins to point to the 'Creating Vim Plugins with Maktaba' section of the wiki.
