### PR TITLE
Detect uncanonicalized plugin dir names on runtimepath

### DIFF
--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -396,10 +396,11 @@ function! maktaba#plugin#Get(name) abort
   endif
 
   " Check if any dir on runtimepath is a plugin that hasn't been detected yet.
-  let l:leafdirs = maktaba#rtp#LeafDirs()
-  if has_key(l:leafdirs, a:name)
-    return maktaba#plugin#GetOrInstall(l:leafdirs[a:name])
-  endif
+  for [l:leafdir, l:leafpath] in items(maktaba#rtp#LeafDirs())
+    if maktaba#plugin#CanonicalName(l:leafdir) is# l:name
+      return maktaba#plugin#GetOrInstall(l:leafpath)
+    endif
+  endfor
 
   throw maktaba#error#NotFound('Plugin %s', a:name)
 endfunction

--- a/vroom/libraries.vroom
+++ b/vroom/libraries.vroom
@@ -88,10 +88,24 @@ even if they haven't been registered with maktaba yet.
 
   :let g:tmpsource = tempname()
   :call mkdir(g:tmpsource)
-  :let g:tmpplugin = maktaba#path#Join([g:tmpsource, 'tmpplugin'])
-  :call mkdir(g:tmpplugin)
-  :let &runtimepath .= ',' . g:tmpplugin
-  :call maktaba#ensure#IsTrue(maktaba#plugin#IsRegistered('tmpplugin'))
+  :function MakeLibDir(name)<CR>
+  |  let l:path = maktaba#path#Join([g:tmpsource, a:name])<CR>
+  |  call mkdir(l:path)<CR>
+  |  call mkdir(maktaba#path#Join([l:path, 'autoload']))<CR>
+  |  return l:path<CR>
+  |endfunction
+  :let &runtimepath .= ',' . MakeLibDir('tmplib1')
+  :call maktaba#library#Require('tmplib1')
+  :call maktaba#ensure#IsTrue(maktaba#plugin#IsRegistered('tmplib1'))
+
+These will be detected even if the directory name is not an exact match, as long
+as it canonicalizes to the same name.
+
+  :let &runtimepath .= ',' . MakeLibDir('vim-tmplib2')
+  :call maktaba#library#Require('tmplib2')
+
+  :let &runtimepath .= ',' . MakeLibDir('tmplib3.vim')
+  :call maktaba#library#Require('tmplib3')
 
 Note that installers are only called the first time a plugin is installed. To
 see this, let's install a louder installer.


### PR DESCRIPTION
Fixes `maktaba#plugin#Get` and downstream functions like `maktaba#library#Require` to detect when a dirname like vim-PLUGINNAME has been added to vim's runtimepath.

I haven't done any serious profiling, but since this code is not a hotspot and only executes at most once per plugin, I'm not too worried about performance regressions. I did a quick check of `time vim -c 'quit'` and my vim startup was about the same before and after.

Partially fixes #112.
Support for checking addon-info.json files to support arbitrary directory names is yet to come, but will be harder to implement without screwing performance.