### PR TITLE
Implement asynchronous execution in Maktaba.

### DIFF
--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -151,7 +151,6 @@ function! maktaba#syscall#DoCallAsync() abort dict
   let s:callbacks[l:output_file] = {
 	\ 'function': maktaba#ensure#IsCallable(self.callback),
 	\ 'tab': tabpagenr()}
-  echomsg s:EscapeSpecialChars(l:full_cmd)
   silent execute '! ' . s:EscapeSpecialChars(l:full_cmd)
   redraw!
   return {}

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -374,6 +374,30 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
   Throws ERROR(WrongType)
   Throws ERROR(ShellError) if the shell command returns an exit code.
 
+Syscall.CallAsync({allow_sync_fallback}, {callback}, [throw_errors])
+                                                         *Syscall.CallAsync()*
+  Asynchronous calls are executed via |--remote-expr| using vim's
+  |clientserver| capabilities, so the preconditions for it are vim being
+  compiled with +clientserver and the |v:servername| being set. Vim will try
+  to set it to something when it starts if it is running in X context, e.g.
+  'GVIM1'. Otherwise, the user needs to set it by passing |--servername| $NAME
+  to vim. If the two conditions are not met, asynchronous calls are not
+  possible, and the call will either throw an error or fallback to synchronous
+  calls, depending on the {allow_sync_fallback} parameter.
+
+  Executes the system asynchronously and invokes the callback on completion.
+  {callback} function will be called on asynchronous command completion, with
+  the following arguments: {callback}(env_dict, result_dict), where env_dict
+  contains tab, buffer, path, column and line info, and the result_dict
+  contains stdout, stderr and status (code). If {allow_sync_fallback} is 1 and
+  async calls are not available, a synchronous call will be executed and
+  callback called with the result. If [throw_errors] is 1, any exit code from
+  the command will cause a ShellError to be thrown. Otherwise, the caller is
+  responsible for checking result_dict.status and handling error conditions.
+  [throw_errors] is 1 if omitted.
+  Throws ERROR(WrongType)
+  Throws ERROR(ShellError) if the shell command returns an exit code.
+
 Syscall.CallForeground({pause}, [throw_errors])     *Syscall.CallForeground()*
   Executes the system call in the foreground, showing the output to the user.
   If {pause} is 1, output will stay on the screen until the user presses
@@ -1404,6 +1428,9 @@ maktaba#string#StartsWith({string}, {prefix})    *maktaba#string#StartsWith()*
 
 maktaba#string#EndsWith({string}, {suffix})        *maktaba#string#EndsWith()*
   Whether or not {string} ends with {suffix}.
+
+maktaba#syscall#IsAsyncAvailable()        *maktaba#syscall#IsAsyncAvailable()*
+  Returns whether the current vim session supports asynchronous calls.
 
 maktaba#syscall#Create({cmd})                       *maktaba#syscall#Create()*
   Creates a |maktaba.Syscall| object that can be used to execute {cmd} with

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -365,24 +365,21 @@ maktaba#system#Or to chain commands.
 To execute system calls asynchronously, use CallAsync.
 
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
-  :function Callback(env, stdout, stderr, exit_code) abort<CR>
+  :function Callback(env, return_data) abort<CR>
   |  let g:env = a:env<CR>
-  |  let g:callback_stdout = a:stdout<CR>
-  |  let g:callback_exit_code = a:exit_code<CR>
+  |  let g:callback_stdout = a:return_data.stdout<CR>
+  |  let g:callback_exit_code = a:return_data.status<CR>
   |endfunction
   :call g:syscall.CallAsync('Callback')
   ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
-  :let g:deadline = localtime() + 5 " wait for at most 4 seconds
+  :let g:deadline = localtime() + 2 " wait for at most 2 seconds
   :while !exists('g:callback_exit_code') && localtime() < g:deadline
-  :  let g:async_failed = 1
-  :  break
   :endwhile
-  :if exists('g:async_failed')
-  :  echomsg "Async callback not run in 5 seconds, failing."
-  :else
-  :  echomsg g:callback_stdout
+  :call maktaba#ensure#IsTrue(exists('g:callback_exit_code'),
+  | 'Async callback was expected to complete within 2 seconds')
+  :echomsg g:callback_stdout
   ~ hi
-  :endif
+
 
 Async calls fall back to synchronous calls if disabled or not available.
 

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -370,7 +370,7 @@ To execute system calls asynchronously, use CallAsync.
   |  let g:callback_stdout = a:return_data.stdout<CR>
   |  let g:callback_exit_code = a:return_data.status<CR>
   |endfunction
-  :call g:syscall.CallAsync('Callback')
+  :call g:syscall.CallAsync('Callback', 0)
   ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
   :let g:deadline = localtime() + 2 " wait for at most 2 seconds
   :while !exists('g:callback_exit_code') && localtime() < g:deadline

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -362,4 +362,19 @@ maktaba#system#Or to chain commands.
   ! false || echo FAILURE
   $ FAILURE
 
+To execute system calls asynchronously, use CallAsync.
+
+  :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
+  :function Callback(stdout, stderr, exit_code) abort<CR>
+  |  let g:callback_stdout = a:stdout<CR>
+  |  let g:callback_exit_code = a:exit_code<CR>
+  |endfunction
+  :call g:syscall.CallAsync('Callback')
+  ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
+  :sleep 2 (2.5s)
+  :echomsg g:callback_stdout
+  ~ hi
+  :echomsg g:callback_exit_code
+  ~ 0
+
   @system

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -365,7 +365,8 @@ maktaba#system#Or to chain commands.
 To execute system calls asynchronously, use CallAsync.
 
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
-  :function Callback(stdout, stderr, exit_code) abort<CR>
+  :function Callback(env, stdout, stderr, exit_code) abort<CR>
+  |  let g:env = a:env<CR>
   |  let g:callback_stdout = a:stdout<CR>
   |  let g:callback_exit_code = a:exit_code<CR>
   |endfunction

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -371,10 +371,23 @@ To execute system calls asynchronously, use CallAsync.
   |endfunction
   :call g:syscall.CallAsync('Callback')
   ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
-  :sleep 2 (2.5s)
-  :echomsg g:callback_stdout
+  :let g:deadline = localtime() + 5 " wait for at most 4 seconds
+  :while !exists('g:callback_exit_code') && localtime() < g:deadline
+  :  let g:async_failed = 1
+  :  break
+  :endwhile
+  :if exists('g:async_failed')
+  :  echomsg "Async callback not run in 5 seconds, failing."
+  :else
+  :  echomsg g:callback_stdout
   ~ hi
-  :echomsg g:callback_exit_code
-  ~ 0
+  :endif
+
+Async calls fall back to synchronous calls if disabled or not available.
+
+  :call maktaba#syscall#SetAsyncDisabled(1)
+  :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
+  :call g:syscall.CallAsync('Callback', 1)
+  ! echo hi 2> .*
 
   @system


### PR DESCRIPTION
Example usage:
```vim
let l:cmd = call maktaba#syscall#Create(['/bin/sleep', '3'])

call l:cmd.CallAsync('CallMeMaybe')
call l:cmd.CallAsync(maktaba#function#Create('CallMeMaybe'))
```

Asynchronous execution works by executing the command in the background
which, after the command is completed, executes "vim --remote-expr" that
uses the vim v:servername to find the originating server and call the
callback.

Requirements:
  - vim compiled with +clientserver
  - vim started with --servername
  - DISPLAY set to same X where vim is running (e.g. when over ssh)

Inspired by pydev/AsyncCommand.
Closes google/vim-maktaba#116.