### PR TITLE
Don't throw errors in async's sync fallback.

### DIFF
--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -131,8 +131,11 @@ function! maktaba#syscall#DoCallAsync() abort dict
       call s:plugin.logger.Warn('Async support not available. ' .
           \ 'Falling back to synchronous execution for system call: ' .
           \ self.GetCommand())
-      let l:return_data = self.Call()
+      " This is called by DoSyscallCommon, which will throw if v:shell_error is
+      " not 0, so we reset it by executing true.
+      let l:return_data = self.Call(0)  " Don't throw ShellError on failure.
       let l:return_data.status = v:shell_error
+      call maktaba#syscall#Create(['true']).Call()
       call maktaba#function#Call(self.callback, [s:CurrentEnv(), l:return_data])
       return {}
     else


### PR DESCRIPTION
If a system call fails under Syscall.CallAsync when async is available,
the exit code, stdout, and stderr are just passed to the handler function,
but if async isn't available, the sync fallback throws a ShellError.

The fallback should forward results to the handler function so you only have to
handle errors in one place.

Closes google/vim-maktaba#121