### PR TITLE
Fix error cases for Syscall.CallAsync

### DIFF
--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -374,29 +374,38 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
   Throws ERROR(WrongType)
   Throws ERROR(ShellError) if the shell command returns an exit code.
 
-Syscall.CallAsync({allow_sync_fallback}, {callback}, [throw_errors])
-                                                         *Syscall.CallAsync()*
+Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
+  Executes the system call asynchronously and invokes {callback} on
+  completion. {callback} function will be called on asynchronous command
+  completion, with the following arguments: {callback}(env_dict, result_dict),
+  where env_dict contains tab, buffer, path, column and line info, and the
+  result_dict contains stdout, stderr and status (code). If
+  {allow_sync_fallback} is 1 and async calls are not available, a synchronous
+  call will be executed and callback called with the result. For example:
+>
+    function Handler(env_dict, result)
+      if a:result.status != 0
+        call maktaba#error#Shout('sleep command failed: %s', a:result.stderr)
+        return
+      endif
+      echomsg 'Success!'
+    endfunction
+    call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
+<
+  WARNING: The caller is responsible for checking result_dict.status and
+  handling error conditions. Otherwise all failures are silent.
+
   Asynchronous calls are executed via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being
   compiled with +clientserver and the |v:servername| being set. Vim will try
   to set it to something when it starts if it is running in X context, e.g.
   'GVIM1'. Otherwise, the user needs to set it by passing |--servername| $NAME
   to vim. If the two conditions are not met, asynchronous calls are not
-  possible, and the call will either throw an error or fallback to synchronous
-  calls, depending on the {allow_sync_fallback} parameter.
-
-  Executes the system asynchronously and invokes the callback on completion.
-  {callback} function will be called on asynchronous command completion, with
-  the following arguments: {callback}(env_dict, result_dict), where env_dict
-  contains tab, buffer, path, column and line info, and the result_dict
-  contains stdout, stderr and status (code). If {allow_sync_fallback} is 1 and
-  async calls are not available, a synchronous call will be executed and
-  callback called with the result. If [throw_errors] is 1, any exit code from
-  the command will cause a ShellError to be thrown. Otherwise, the caller is
-  responsible for checking result_dict.status and handling error conditions.
-  [throw_errors] is 1 if omitted.
+  possible, and the call will either throw |ERROR(MissingFeature)| or fall
+  back to synchronous calls, depending on the {allow_sync_fallback} parameter.
   Throws ERROR(WrongType)
-  Throws ERROR(ShellError) if the shell command returns an exit code.
+  Throws ERROR(MissingFeature) if neither async execution nor fallback is
+  available.
 
 Syscall.CallForeground({pause}, [throw_errors])     *Syscall.CallForeground()*
   Executes the system call in the foreground, showing the output to the user.

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -364,24 +364,24 @@ Syscall.Or({cmd})                                               *Syscall.Or()*
 
 Syscall.Call([throw_errors])                                  *Syscall.Call()*
   Executes the system call without showing output to the user. If
-  [throw_errors] is 1, any exit code from the command will cause a ShellError
-  to be thrown. Otherwise, the caller is responsible for checking
+  [throw_errors] is 1, any non-zero exit code from the command will cause a
+  ShellError to be thrown. Otherwise, the caller is responsible for checking
   |v:shell_error| and handling error conditions.
   [throw_errors] is 1 if omitted.
   Returns a dictionary with the following fields:
     * stdout: the shell command's entire stdout string, if available.
     * stderr: the shell command's entire stderr string, if available.
   Throws ERROR(WrongType)
-  Throws ERROR(ShellError) if the shell command returns an exit code.
+  Throws ERROR(ShellError) if the shell command returns a non-zero exit code.
 
 Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   Executes the system call asynchronously and invokes {callback} on
-  completion. {callback} function will be called on asynchronous command
-  completion, with the following arguments: {callback}(env_dict, result_dict),
-  where env_dict contains tab, buffer, path, column and line info, and the
-  result_dict contains stdout, stderr and status (code). If
-  {allow_sync_fallback} is 1 and async calls are not available, a synchronous
-  call will be executed and callback called with the result. For example:
+  completion. {callback} function will be called with the following arguments:
+  {callback}(env_dict, result_dict), where env_dict contains tab, buffer,
+  path, column and line info, and the result_dict contains stdout, stderr and
+  status (code). If {allow_sync_fallback} is 1 and async calls are not
+  available, a synchronous call will be executed and callback called with the
+  result. For example:
 >
     function Handler(env_dict, result)
       if a:result.status != 0
@@ -393,12 +393,12 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
     call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
 <
   WARNING: The caller is responsible for checking result_dict.status and
-  handling error conditions. Otherwise all failures are silent.
+  handling unexpected exit codes. Otherwise all failures are silent.
 
   Asynchronous calls are executed via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being
-  compiled with +clientserver and the |v:servername| being set. Vim will try
-  to set it to something when it starts if it is running in X context, e.g.
+  compiled with +clientserver and |v:servername| being set. Vim will try to
+  set it to something when it starts if it is running in X context, e.g.
   'GVIM1'. Otherwise, the user needs to set it by passing |--servername| $NAME
   to vim. If the two conditions are not met, asynchronous calls are not
   possible, and the call will either throw |ERROR(MissingFeature)| or fall
@@ -410,15 +410,15 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
 Syscall.CallForeground({pause}, [throw_errors])     *Syscall.CallForeground()*
   Executes the system call in the foreground, showing the output to the user.
   If {pause} is 1, output will stay on the screen until the user presses
-  Enter. If [throw_errors] is 1, any exit code from the command will cause a
-  ShellError to be thrown. Otherwise, the caller is responsible for checking
-  |v:shell_error| and handling error conditions.
+  Enter. If [throw_errors] is 1, any non-zero exit code from the command will
+  cause a ShellError to be thrown. Otherwise, the caller is responsible for
+  checking |v:shell_error| and handling error conditions.
   [throw_errors] is 1 if omitted.
   Returns a dictionary with the following fields:
     * stdout: the shell command's entire stdout string, if available.
     * stderr: the shell command's entire stderr string, if available.
   Throws ERROR(WrongType)
-  Throws ERROR(ShellError) if the shell command returns an exit code.
+  Throws ERROR(ShellError) if the shell command returns a non-zero exit code.
   Throws ERROR(NotImplemented) if stdin has been specified for this Syscall.
 
 Syscall.GetCommand()                                    *Syscall.GetCommand()*


### PR DESCRIPTION
Forward errors to handler even in sync fallback and get rid of throw_errors arg that didn't work as advertised.
Also switch from ERROR(ShellError) to ERROR(MissingFeature) and remove return value from CallAsync.

Fixes #121.