### PR TITLE
Fix issue: Syscall.CallAsync ignores WithStdin.

### DIFF
--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -140,7 +140,12 @@ function! maktaba#syscall#DoCallAsync() abort dict
   let s:callbacks[l:output_file] = {
       \ 'function': maktaba#ensure#IsCallable(self.callback),
       \ 'env': s:CurrentEnv()}
-  call system(l:full_cmd)
+
+  if has_key(self, 'stdin')
+    call system(l:full_cmd, self.stdin)
+  else
+    call system(l:full_cmd)
+  endif
   return {}
 endfunction
 

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -388,7 +388,7 @@ To execute system calls asynchronously, use CallAsync.
 Asynchronous calls can also take a stdin parameter.
 
   :unlet g:callback_stdout
-  :unlet g:callback_stderr
+  :unlet g:env
   :unlet g:callback_exit_code
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
   :call g:syscall.CallAsync('Callback', 0)

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -385,6 +385,13 @@ To execute system calls asynchronously, use CallAsync.
   :echomsg g:callback_stdout
   ~ hi
 
+Asynchronous calls can also take a stdin parameter.
+
+  :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
+  :call g:syscall.CallAsync('Callback', 0)
+  ! .*cat; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
+  :echomsg g:callback_stdout
+  ~ Hello
 
 Async calls fall back to synchronous calls if disabled or not available.
 

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -387,9 +387,17 @@ To execute system calls asynchronously, use CallAsync.
 
 Asynchronous calls can also take a stdin parameter.
 
+  :unlet g:callback_stdout
+  :unlet g:callback_stderr
+  :unlet g:callback_exit_code
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
   :call g:syscall.CallAsync('Callback', 0)
   ! .*cat; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
+  :let g:deadline = localtime() + 2 " wait for at most 2 seconds
+  :while !exists('g:callback_exit_code') && localtime() < g:deadline
+  :endwhile
+  :call maktaba#ensure#IsTrue(exists('g:callback_exit_code'),
+  | 'Async callback was expected to complete within 2 seconds')
   :echomsg g:callback_stdout
   ~ Hello
 


### PR DESCRIPTION
Even if .WithStdin is invoked on a Syscall, when runnin asynchronously,
this is ignored.

Fix the issue and add a test case for it.

Closes google/vim-maktaba#127.