### PR TITLE
Fix helloworld to find maktaba from containing repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - sudo dpkg -i ./vroom_0.12.0-1_all.deb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
-  - vroom $VROOM_ARGS --crawl ./vroom/
+  - vroom $VROOM_ARGS --crawl
 matrix:
   fast_finish: true
   allow_failures:

--- a/examples/helloworld/bootstrap.vim
+++ b/examples/helloworld/bootstrap.vim
@@ -9,6 +9,7 @@
 " Please excuse the mess.
 
 let s:thisplugin = expand('<sfile>:p:h')
+
 if !exists('*maktaba#compatibility#Disable')
   try
     " To check if Maktaba is loaded we must try calling a maktaba function.
@@ -17,10 +18,26 @@ if !exists('*maktaba#compatibility#Disable')
   catch /E117:/
     " Maktaba is not installed. Check whether it's in a nearby directory.
     let s:rtpsave = &runtimepath
+    let s:search_dirs = [fnamemodify(s:thisplugin, ':h')]
+    " Since this plugin lives in maktaba/examples/, fall back to installing
+    " maktaba from the containing maktaba repository.
+    if fnamemodify(s:thisplugin, ':h:t') is# 'examples'
+      let s:search_dirs += [fnamemodify(s:thisplugin, ':h:h:h')]
+    endif
+    let s:search_paths = []
     " We'd like to use maktaba#path#Join, but maktaba doesn't exist yet.
     let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
-    let s:pathguess = fnamemodify(s:thisplugin, ':h') . s:slash . 'maktaba'
-    let &runtimepath .= ',' . s:pathguess
+    for s:search_dir in s:search_dirs
+      call add(s:search_paths, s:search_dir . s:slash . 'maktaba')
+      call add(s:search_paths, s:search_dir . s:slash . 'vim-maktaba')
+    endfor
+    for s:search_path in s:search_paths
+      if isdirectory(s:search_path)
+        let &runtimepath .= ',' . s:search_path
+        break
+      endif
+    endfor
+
     try
       " If we've just installed maktaba, we need to make sure that vi
       " compatibility mode is off. Maktaba does not support vi compatibility.
@@ -31,10 +48,10 @@ if !exists('*maktaba#compatibility#Disable')
       unlet s:rtpsave
       " We'd like to use maktaba#error#Shout, but maktaba doesn't exist yet.
       echohl ErrorMsg
-      echomsg
-          \ 'Maktaba not found! helloworld depends upon maktaba. Please either:'
+      echomsg 'Maktaba not found, but helloworld requires it. Please either:'
       echomsg '1. Place maktaba in the same directory as this plugin.'
       echomsg '2. Add maktaba to your runtimepath before using this plugin.'
+      echomsg 'Maktaba can be found at http://github.com/google/vim-maktaba.'
       echohl NONE
       finish
     endtry


### PR DESCRIPTION
Update helloworld's bootstrap.vim so it falls back to installing maktaba from the containing repo if it's not available otherwise. In particular, this fixes the vroom tests since so they have their maktaba dependency satisfied.

Also re-enables tests on Travis CI now that they pass again.

Fixes #68.