### PR TITLE
Fix maktaba#path#Exists() to be independent of user options

### DIFF
--- a/autoload/maktaba/path.vim
+++ b/autoload/maktaba/path.vim
@@ -217,7 +217,7 @@ function! maktaba#path#Exists(path) abort
   let l:path_glob = substitute(l:path_glob, '\V[', '[[]', 'g')
   let l:path_glob = substitute(l:path_glob, '\V*', '[*]', 'g')
   let l:path_glob = substitute(l:path_glob, '\V?', '[\?]', 'g')
-  return !empty(glob(l:path_glob))
+  return !empty(glob(l:path_glob, 1))
 endfunction
 
 


### PR DESCRIPTION
I happened to notice a bug that makes `maktaba#path#Exists()` depend on the `'suffixes'` and `'wildignore'` settings:
```vim
:set wildignore+=*.vim
:echo maktaba#path#Exists('autoload/maktaba.vim')
```