### PR TITLE
Implement a registry mechanism for plugins

### DIFF
--- a/autoload/maktaba/extension.vim
+++ b/autoload/maktaba/extension.vim
@@ -1,0 +1,182 @@
+""
+" @dict ExtensionRegistry
+" A registry for the extensions used by a single plugin.  Extensions are
+" dictionaries (usually with some function fields) with a plugin-specific
+" interpretation.
+"
+" Plugins should use @function(Plugin.GetExtensionRegistry) to gain
+" access to their own extension registry, and @function(#GetRegistry) to gain
+" access to an extension registry for another plugin.
+"
+" For example, a hypothetical code-formatting plugin would use the following
+" to retrieve a list of extensions, where each extension represents a
+" formatter for a particular filetype:
+" >
+"   let [s:plugin, s:enter] = maktaba#plugin#Enter(expand('<sfile>:p'))
+"   ...
+"   let l:registry = s:plugin.GetExtensionRegistry()
+"   for l:extension in l:registry.GetExtensions()
+"     if &filetype is# l:extension.filetype
+"       call maktaba#function#Call(l:extension.FormatBuffer)
+"       return
+"     endif
+"   endfor
+" <
+" Likewise, a plugin providing another formatter would use the following to
+" register a new extension:
+" >
+"   let l:extension = {
+"       \ 'filetype': 'python',
+"       \ 'FormatBuffer': function('pyformatter#FormatUsingAutopep8'),
+"       \ }
+"   let l:codefmt_registry = maktaba#extension#GetRegistry('code-formatting')
+"   call l:codefmt_registry.AddExtension(l:extension)
+" <
+" See the Vroom tests in the Maktaba source tree (pluginextensions.vroom) for
+" more examples.
+
+
+" Extension registry objects, keyed by plugin name.
+if !exists('s:registries')
+  let s:registries = {}
+endif
+
+
+""
+" @private
+" Returns an extension registry for the given plugin name, creating it if
+" needed.
+" @throws WrongType if {plugin} is not a string.
+function! maktaba#extension#GetInternalRegistry(plugin) abort
+  call maktaba#ensure#IsString(a:plugin)
+
+  if has_key(s:registries, a:plugin)
+    return s:registries[a:plugin]
+  endif
+
+  let l:registry = {
+      \ 'AddExtension': function('maktaba#extension#AddExtension'),
+      \ 'GetExtensions': function('maktaba#extension#GetExtensions'),
+      \ 'SetValidator': function('maktaba#extension#SetValidator'),
+      \ '_internal_extensions': [],
+      \ '_external_extensions': [],
+      \ '_validator': maktaba#function#FromExpr('0'),
+      \ '_external': 0,
+      \ }
+  let s:registries[a:plugin] = l:registry
+  return l:registry
+endfunction
+
+
+""
+" Returns an extension registry for the given plugin name.
+" @throws WrongType if {plugin} is not a string.
+function! maktaba#extension#GetRegistry(plugin) abort
+  let l:registry = maktaba#extension#GetInternalRegistry(a:plugin)
+
+  " Return an external version of the extension registry with a more limited
+  " interface.
+  let l:registry = copy(l:registry)
+  let l:registry._external = 1
+
+  return l:registry
+endfunction
+
+
+""
+" @dict ExtensionRegistry
+" Adds the given {extension} to this extension registry.
+"
+" The extension must be a dict.  If a validator is registered for this
+" extension registry, this function will call the validator.  Failures will
+" result in the validation error being shouted to the user (and the extension
+" will not be added).
+"
+" @throws WrongType if {extension} is not a dict.
+function! maktaba#extension#AddExtension(extension) dict abort
+  call maktaba#ensure#IsDict(a:extension)
+  let l:extension = deepcopy(a:extension)
+  lockvar! l:extension
+
+  try
+    call maktaba#function#Call(self._validator, [l:extension])
+  catch
+    call maktaba#error#Shout(v:exception)
+    return
+  endtry
+
+  if self._external
+    call insert(self._external_extensions, l:extension)
+  else
+    call insert(self._internal_extensions, l:extension)
+  endif
+endfunction
+
+
+""
+" @dict ExtensionRegistry
+" Returns the extensions that have been added to this extension registry.
+"
+" Extensions added by the plugin to its own registry are always returned
+" after those added by other plugins.  Otherwise, extensions are returned in
+" the opposite order to which they were added.
+"
+" This function is only available to the plugin that the extension registry
+" belongs to.
+" @throws NotImplemented if called by another plugin.
+function! maktaba#extension#GetExtensions() dict abort
+  if self._external
+    throw maktaba#error#NotImplemented('Not accessible by external plugins.')
+  endif
+
+  return self._external_extensions + self._internal_extensions
+endfunction
+
+
+" Loops over {extensions}, calling {validator} for each one.
+" If {validator} throws an error, shouts it to the user and removes it from
+" the list.
+function! s:ValidateExtensionList(extensions, F)
+  let l:index = 0
+  while l:index < len(a:extensions)
+    try
+      call maktaba#function#Call(a:F, [a:extensions[l:index]])
+      let l:index += 1
+    catch
+      call remove(a:extensions, l:index)
+      call maktaba#error#Shout(v:exception)
+    endtry
+  endwhile
+endfunction
+
+
+""
+" @dict ExtensionRegistry
+" Sets {validator} as the validator for this extension registry.
+"
+" {validator} can be the name of a function, funcref, or Maktaba funcdict.
+" It should accept an arbitrary dict (the extension) and throw an error if the
+" extension if invalid.
+"
+" This function will call the validator for any extensions that have already
+" been registered.  Failures will cause the extension to be removed, and the
+" error shouted to the user.
+"
+" This function is only available to the plugin that the extension registry
+" belongs to.
+"
+" @throws WrongType if {validator} is not a string, funcref, nor dict.
+" @throws BadValue if {validator} is a dict but does not appear to be a
+"     funcdict.
+" @throws NotImplemented if called by another plugin.
+function! maktaba#extension#SetValidator(F) dict abort
+  call maktaba#ensure#IsCallable(a:F)
+  if self._external
+    throw maktaba#error#NotImplemented('Not accessible by external plugins.')
+  endif
+
+  let self._validator = a:F
+
+  call s:ValidateExtensionList(self._internal_extensions, a:F)
+  call s:ValidateExtensionList(self._external_extensions, a:F)
+endfunction

--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -470,6 +470,7 @@ function! s:CreatePluginObject(name, location, settings) abort
       \ 'GenerateHelpTags': function('maktaba#plugin#GenerateHelpTags'),
       \ 'MapPrefix': function('maktaba#plugin#MapPrefix'),
       \ 'IsLibrary': function('maktaba#plugin#IsLibrary'),
+      \ 'GetExtensionRegistry': function('maktaba#plugin#GetExtensionRegistry'),
       \ '_entered': l:entrycontroller,
       \ }
   " If plugin has an addon-info.json file with a "name" declared, overwrite the
@@ -882,6 +883,18 @@ function! maktaba#plugin#IsLibrary() dict abort
     endif
   endfor
   return self.HasDir('autoload')
+endfunction
+
+
+""
+" @dict Plugin
+" Returns the @dict(ExtensionRegistry) belonging to this plugin.
+"
+" This should be used only by the plugin itself; external callers should use
+" @function(maktaba#extension#GetRegistry) instead, rather than depend upon
+" the plugin directly.
+function! maktaba#plugin#GetExtensionRegistry() dict abort
+  return maktaba#extension#GetInternalRegistry(self.name)
 endfunction
 
 

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -77,6 +77,82 @@ Enum.Value({name})                                              *Enum.Value()*
 Enum.Values()                                                  *Enum.Values()*
   Gets all values on the enum, in order.
 
+                                                   *maktaba.ExtensionRegistry*
+A registry for the extensions used by a single plugin.  Extensions are
+dictionaries (usually with some function fields) with a plugin-specific
+interpretation.
+
+Plugins should use |Plugin.GetExtensionRegistry()| to gain access to their own
+extension registry, and |maktaba#extension#GetRegistry()| to gain access to an
+extension registry for another plugin.
+
+For example, a hypothetical code-formatting plugin would use the following to
+retrieve a list of extensions, where each extension represents a formatter for
+a particular filetype:
+>
+  let [s:plugin, s:enter] = maktaba#plugin#Enter(expand('<sfile>:p'))
+  ...
+  let l:registry = s:plugin.GetExtensionRegistry()
+  for l:extension in l:registry.GetExtensions()
+    if &filetype is# l:extension.filetype
+      call maktaba#function#Call(l:extension.FormatBuffer)
+      return
+    endif
+  endfor
+<
+Likewise, a plugin providing another formatter would use the following to
+register a new extension:
+>
+  let l:extension = {
+      \ 'filetype': 'python',
+      \ 'FormatBuffer': function('pyformatter#FormatUsingAutopep8'),
+      \ }
+  let l:codefmt_registry = maktaba#extension#GetRegistry('code-formatting')
+  call l:codefmt_registry.AddExtension(l:extension)
+<
+See the Vroom tests in the Maktaba source tree (pluginextensions.vroom) for
+more examples.
+
+ExtensionRegistry.AddExtension({extension}) *ExtensionRegistry.AddExtension()*
+  Adds the given {extension} to this extension registry.
+
+  The extension must be a dict.  If a validator is registered for this
+  extension registry, this function will call the validator.  Failures will
+  result in the validation error being shouted to the user (and the extension
+  will not be added).
+
+  Throws ERROR(WrongType) if {extension} is not a dict.
+
+ExtensionRegistry.GetExtensions()          *ExtensionRegistry.GetExtensions()*
+  Returns the extensions that have been added to this extension registry.
+
+  Extensions added by the plugin to its own registry are always returned after
+  those added by other plugins.  Otherwise, extensions are returned in the
+  opposite order to which they were added.
+
+  This function is only available to the plugin that the extension registry
+  belongs to.
+  Throws ERROR(NotImplemented) if called by another plugin.
+
+ExtensionRegistry.SetValidator({validator}) *ExtensionRegistry.SetValidator()*
+  Sets {validator} as the validator for this extension registry.
+
+  {validator} can be the name of a function, funcref, or Maktaba funcdict. It
+  should accept an arbitrary dict (the extension) and throw an error if the
+  extension if invalid.
+
+  This function will call the validator for any extensions that have already
+  been registered.  Failures will cause the extension to be removed, and the
+  error shouted to the user.
+
+  This function is only available to the plugin that the extension registry
+  belongs to.
+
+  Throws ERROR(WrongType) if {validator} is not a string, funcref, nor dict.
+  Throws ERROR(BadValue) if {validator} is a dict but does not appear to be a
+      funcdict.
+  Throws ERROR(NotImplemented) if called by another plugin.
+
                                                                 *maktaba.Flag*
 The maktaba flag object. Exposes functions that operate on an individual
 maktaba flag.
@@ -285,6 +361,13 @@ Plugin.IsLibrary()                                        *Plugin.IsLibrary()*
   ftplugin/, ftdetect/, syntax/, indent/, nor instant/ directories. If it
   contains a plugin/ directory, that directory must contain only a flags.vim
   file.
+
+Plugin.GetExtensionRegistry()                  *Plugin.GetExtensionRegistry()*
+  Returns the |maktaba.ExtensionRegistry| belonging to this plugin.
+
+  This should be used only by the plugin itself; external callers should use
+  |maktaba#extension#GetRegistry()| instead, rather than depend upon the
+  plugin directly.
 
                                                              *maktaba.Setting*
 Parses {text} into a setting object. The setting object can be applied to a
@@ -749,6 +832,10 @@ maktaba#error#TryCommand({command}, [exceptions]) *maktaba#error#TryCommand()*
   function.
   [exceptions] is .* if omitted.
   Throws ERROR(WrongType) if [exceptions] is neither a regex nor a list.
+
+maktaba#extension#GetRegistry({plugin})      *maktaba#extension#GetRegistry()*
+  Returns an extension registry for the given plugin name.
+  Throws ERROR(WrongType) if {plugin} is not a string.
 
 maktaba#filetype#IsEnabled()                    *maktaba#filetype#IsEnabled()*
   Returns 1 if filetype detection is enabled in vim, 0 otherwise.

--- a/vroom/plugin.vroom
+++ b/vroom/plugin.vroom
@@ -226,6 +226,7 @@ Here's a directory of relevant topics:
 * pluginfiles.vroom.........................................MAKTABA PLUGIN FILES
 * pluginflags.vroom.......................CONFIGURING MAKTABA PLUGINS WITH FLAGS
 * plugincontrol.vroom............................CONTROLLING PLUGIN FILE LOADING
+* pluginextensions.vroom......DEFINING EXTENSION POINTS FOR OTHER PLUGINS TO USE
 * pluginutil.vroom...................................ADDITIONAL PLUGIN UTILITIES
 * ftplugin.vroom................................................FILETYPE PLUGINS
 * helptags.vroom..............................................HELPTAG GENERATION

--- a/vroom/pluginextensions.vroom
+++ b/vroom/pluginextensions.vroom
@@ -1,0 +1,194 @@
+Maktaba allows plugins to define extension points that other plugins can
+make use of. For example, a code formatting plugin could allow other plugins
+to register extensions to handle specific file types.
+
+This provides a convenient alternative to separating out the registration
+functionality into a separate library plugin, which is annoying if there
+would otherwise be no reason for that separate plugin to exist.
+
+Before we can see how this all works, we'll have to install Maktaba:
+
+  :set nocompatible
+  :let g:maktabadir = fnamemodify($VROOMFILE, ':p:h:h')
+  :let g:bootstrapfile = g:maktabadir . '/bootstrap.vim'
+  :execute 'source' g:bootstrapfile
+
+and a fake plugin:
+
+  :let g:thisdir = fnamemodify($VROOMFILE, ':p:h')
+  :let g:repo = maktaba#path#Join([g:thisdir, 'fakeplugins'])
+  :let g:pluginpath = maktaba#path#Join([g:repo, 'myplugin'])
+  :let g:plugin = maktaba#plugin#Install(g:pluginpath)
+
+Plugins have an individual 'extension registry' that holds all the
+extensions registered for use by that plugin.
+
+A plugin obtain its own extension registry via the existing plugin object.
+
+  :let g:registry = g:plugin.GetExtensionRegistry()
+
+A plugin's extension registry contains functions to modify and query the
+list of extensions registered for that plugin, and to define what makes a
+valid extension.
+
+Extensions are arbitrary dictionaries, so a plugin providing an extension
+point can optionally (and should) register a validator that will check that
+a provided extension is acceptable, via the extension registry's
+SetValidator() function.
+
+  :function! MyFormatterValidator(extension) abort
+  :  if !has_key(a:extension, 'filetype')
+  :    throw maktaba#error#BadValue('No filetype.')
+  :  endif
+  :  if !has_key(a:extension, 'command')
+  :    throw maktaba#error#BadValue('No command.')
+  :  endif
+  :endfunction
+  :call g:registry.SetValidator('MyFormatterValidator')
+
+SetValidator() accepts a string, funcref, or Maktaba function dictionary,
+just like maktaba#function#Call().
+
+
+Now, when a second plugin comes to register an extension for the above
+plugin to use, it must also get access to that plugin's extension registry.
+
+Note that the second plugin cannot use the above mechanism to do so, as it
+would require that plugin to load the first plugin directly, which would
+only be permitted if that was a library plugin.
+
+Instead, Maktaba allows plugins to register extensions against the name of
+the original plugin. This does not require that the original plugin is
+installed (or even that it will be installed - it is not an error to
+register extensions against plugins that the user is not using).
+
+The following would normally be run from a separate plugin during loading,
+but for the purposes of exposition, we're going to make the calls directly.
+
+This time, the extension registry is obtained from a call to
+maktaba#extension#GetRegistry().
+
+  :let g:registry = maktaba#extension#GetRegistry('myplugin')
+
+Once the plugin has an extension registry for the target plugin, it can add
+extensions using the AddExtension() function.
+
+  :let g:foo_extension = {'filetype': 'foo', 'command': 'foo-format'}
+  :call g:registry.AddExtension(g:foo_extension)
+
+If the original plugin has registered a validator (as is the case here), the
+validator will be called to verify the extension.  Any errors returned from
+the validator will be shouted to the user (and will prevent the extension
+from being registered), but will not be propagated to the caller.
+
+  :let g:registry = maktaba#extension#GetRegistry('myplugin')
+  :let g:bad_extension = {'command': 'bad-format'}
+  :call g:registry.AddExtension(g:bad_extension)
+  ~ ERROR(BadValue): No filetype.
+  :let g:bar_extension = {'filetype': 'bar', 'command': 'bar-format'}
+  :call g:registry.AddExtension(g:bar_extension)
+
+The original plugin can now retrieve the list of extensions from its
+extension registry.
+
+  :let g:registry = g:plugin.GetExtensionRegistry()
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'filetype': 'bar', 'command': 'bar-format'},
+  | {'filetype': 'foo', 'command': 'foo-format'}]
+
+New extensions are inserted at the front of the list, with one exception,
+noted below.
+
+
+Note that the registry object returned by maktaba#extension#GetRegistry() is
+limited compared to the one returned by GetExtensionRegistry() in that the
+SetValidator() and GetExtensions() functions are not implemented.
+
+  :let g:registry = maktaba#extension#GetRegistry('myplugin')
+  :call maktaba#error#Try(maktaba#function#Method(g:registry, 'GetExtensions'))
+  ~ ERROR(NotImplemented): Not accessible by external plugins.
+  :call maktaba#error#Try(maktaba#function#Method(g:registry, 'SetValidator')
+  |.WithArgs('MyFormatterValidator'))
+  ~ ERROR(NotImplemented): Not accessible by external plugins.
+
+Extensions can also be registered by the plugin providing the extension
+point, which can used as a way of providing default implementations that
+other plugins can override.
+
+This is done simply by calling AddExtension(), as usual.
+
+  :let g:registry = g:plugin.GetExtensionRegistry()
+  :let g:baz_extension = {'filetype': 'baz', 'command': 'baz-format'}
+  :call g:registry.AddExtension(g:baz_extension)
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'filetype': 'bar', 'command': 'bar-format'},
+  | {'filetype': 'foo', 'command': 'foo-format'},
+  | {'filetype': 'baz', 'command': 'baz-format'}]
+
+There is one important difference here: extensions added via the internal
+interface will always follow those added via the external interface.
+
+The rationale behind this ordering is that is easier for plugins to choose
+the first applicable extension (if more than one is applicable), and that
+plugin authors may also wish to register extensions that provide some form
+of 'default' functionality that can be overridden by a (possibly earlier)
+call to AddExtension() by an external plugin.
+
+
+As mentioned above, plugins may register an extension before the plugin
+providing the extension point is installed (if it is installed at all).
+
+Here we'll register an extension for the emptyplugin plugin.
+
+  :let g:registry = maktaba#extension#GetRegistry('emptyplugin')
+  :let g:empty_extension = {'emptiness': 'empty'}
+  :call g:registry.AddExtension(g:empty_extension)
+
+We could choose not to install that plugin, but we'll do so now.
+
+  :let g:emptypluginpath = maktaba#path#Join([g:repo, 'emptyplugin'])
+  :let g:emptyplugin = maktaba#plugin#Install(g:emptypluginpath)
+
+The emptyplugin plugin already has access to the extension we added.
+
+  :let g:registry = g:emptyplugin.GetExtensionRegistry()
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'emptiness': 'empty'}]
+
+
+Let's add one of the extensions we defined earlier as well.
+
+  :let g:registry = maktaba#extension#GetRegistry('emptyplugin')
+  :call g:registry.AddExtension(g:foo_extension)
+
+If the emptyplugin plugin now sets a validator, Maktaba will check the
+extensions that have already been added to make sure that they are still
+valid.  We'll reuse the validator we had before, so the first extension we
+added above will fail.
+
+  :let g:registry = g:emptyplugin.GetExtensionRegistry()
+  :call g:registry.SetValidator('MyFormatterValidator')
+  ~ ERROR(BadValue): No filetype.
+
+As AddExtension() did, SetValidator() will shout validation errors to the
+user, but will also remove extensions that no longer validate.
+
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'filetype': 'foo', 'command': 'foo-format'}]
+
+We can change the current validator to something more permissive, though
+that won't bring back the invalid extension.
+
+  :call g:registry.SetValidator(maktaba#function#FromExpr('0'))
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'filetype': 'foo', 'command': 'foo-format'}]
+
+We can add it back, though.
+
+  :let g:registry = maktaba#extension#GetRegistry('emptyplugin')
+  :call g:registry.AddExtension(g:empty_extension)
+
+  :let g:registry = g:emptyplugin.GetExtensionRegistry()
+  :echomsg string(g:registry.GetExtensions())
+  ~ [{'emptiness': 'empty'},
+  | {'filetype': 'foo', 'command': 'foo-format'}]


### PR DESCRIPTION
Create a way for plugins to register extensions (arbitrary optionally-validated dicts) against other plugins, avoiding the need to split out small library plugins just for registration (e.g. `vim-codefmtlib`) .

Fixes #130.