### PR TITLE
Optimize critical maktaba#path# functions

### DIFF
--- a/autoload/maktaba/path.vim
+++ b/autoload/maktaba/path.vim
@@ -92,14 +92,14 @@ endfunction
 " Joins the list {components} together using the system separator character.
 " Works like python's os.path.join in that
 " >
-"   Join('relative', '/absolute')
+"   Join(['relative', '/absolute'])
 " <
 " is '/absolute'
 function! maktaba#path#Join(components) abort
   call maktaba#ensure#IsList(a:components)
   " We work through the components backwards because Join returns the rightmost
   " absolute path (if any absolute paths are created).
-  let l:components = reverse(a:components)
+  let l:components = reverse(copy(a:components))
   " You might think this code can be simplified by initializing l:path to ''.
   " This is not the case: joining a component with an empty string ensures
   " a trailing slash. If we were to start with l:path = '' then

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1153,7 +1153,7 @@ maktaba#path#Join({components})                          *maktaba#path#Join()*
   Joins the list {components} together using the system separator character.
   Works like python's os.path.join in that
 >
-    Join('relative', '/absolute')
+    Join(['relative', '/absolute'])
 <
   is '/absolute'
 


### PR DESCRIPTION
Optimizes `maktaba#path#Dirname` to reduce the number of calls to some hot spots (`maktaba#path#Split`, `maktaba#path#Join` and `maktaba#path#RootComponent`).

Excerpt from my profiling results before and after:
```
count  total (s)   self (s)  function
-   45   0.104520   0.003073  maktaba#plugin#GetOrInstall()
+   45   0.082889   0.002962  maktaba#plugin#GetOrInstall()
-    1   0.073113   0.000327  maktaba#plugin#Detect()
+    1   0.060265   0.000320  maktaba#plugin#Detect()
-  325   0.052764   0.030335  maktaba#path#Join()
+  207   0.022298   0.014177  maktaba#path#Join()
-  118   0.038825   0.003174  maktaba#path#Dirname()
+  118   0.018949   0.000688  maktaba#path#Dirname()
+  118   0.018261   0.017616  <SNR>8_SplitLast()
-   29   0.018785   0.001267  maktaba#plugin#Source()
+   29   0.017446   0.001285  maktaba#plugin#Source()
-    3   0.015629   0.000174  maktaba#plugin#Get()
+    3   0.014142   0.000180  maktaba#plugin#Get()
-   13   0.015480   0.001293  maktaba#plugin#Enter()
+   13   0.010022   0.001184  maktaba#plugin#Enter()
-  712   0.010647             <SNR>8_Join()
+  240   0.004137             <SNR>8_Join()
- 1337   0.009821             maktaba#path#RootComponent()
+  629   0.002986             maktaba#path#RootComponent()
-  182   0.008065   0.006493  maktaba#path#Split()
+   64   0.002457   0.002161  maktaba#path#Split()
-  431   0.004035   0.001996  maktaba#ensure#IsList()
+  313   0.002925   0.001431  maktaba#ensure#IsList()
-  208   0.003845             maktaba#path#AsDir()
+  208   0.003586             maktaba#path#AsDir()
-  653   0.003129             maktaba#ensure#TypeMatches()
+  535   0.002580             maktaba#ensure#TypeMatches()
```
The bottom line improvement isn't huge (10–20ms for me), but it's consistent. Note the dramatic decrease in call count to RootComponent and other decreases in Split and Join functions.

Also fixes #136.