### PR TITLE
Optimize maktaba#plugin#Get and Detect

### DIFF
--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -11,6 +11,15 @@ if !exists('s:plugins_by_location')
   let s:plugins_by_location = {}
 endif
 
+" Blob of data used by s:GetUnregisteredLeafdirs() for caching:
+"  * The 'leafdirs' field is the cached dict of unregistered leafdirs to return.
+"  * The 'rtp' and 'plugin_locations' fields are the last seen &rtp and
+"    keys(s:plugins_by_location) values, used to invalidate the cache on
+"    changes.
+if !exists('s:unregistered_leafdirs_cache')
+  let s:unregistered_leafdirs_cache = {}
+endif
+
 " Recognized special directories are as follows:
 "
 " autoload/*: Files containing functions made available upon request.
@@ -99,6 +108,30 @@ endfunction
 " Doesn't apply sophisticated heuristics like stripping 'vim-' prefix.
 function! s:SanitizedName(name) abort
   return substitute(a:name, '[^_a-zA-Z0-9]', '_', 'g')
+endfunction
+
+
+""
+" Gets a dictionary of {leaf path} for each path found on &rtp that does not
+" correspond to a registered plugin.
+function! s:GetUnregisteredLeafdirs() abort
+  let l:cache = s:unregistered_leafdirs_cache
+  let l:plugin_locations = keys(s:plugins_by_location)
+  if !has_key(l:cache, 'rtp') || !has_key(l:cache, 'plugin_locations') ||
+      \ l:cache.rtp isnot# &rtp ||
+      \ l:cache.plugin_locations != l:plugin_locations
+    let l:leafdirs = {}
+    for [l:leafdir, l:leafpath] in items(maktaba#rtp#LeafDirs())
+      if !has_key(s:plugins_by_location, l:leafpath)
+        " Path is not a plugin location. Include in return value.
+        let l:leafdirs[l:leafdir] = l:leafpath
+      endif
+    endfor
+    let l:cache.leafdirs = l:leafdirs
+    let l:cache.rtp = &rtp
+    let l:cache.plugin_locations = l:plugin_locations
+  endif
+  return l:cache.leafdirs
 endfunction
 
 
@@ -260,7 +293,7 @@ endfunction
 " Scans 'runtimepath' for any unregistered plugins and registers them with
 " maktaba. May trigger instant/ hooks for newly-registered plugins.
 function! maktaba#plugin#Detect() abort
-  for [l:name, l:location] in items(maktaba#rtp#LeafDirs())
+  for [l:name, l:location] in items(s:GetUnregisteredLeafdirs())
     call maktaba#plugin#GetOrInstall(l:location)
   endfor
 endfunction
@@ -303,14 +336,7 @@ endfunction
 " then maktaba can't handle a plugin named "plugins/myplugin". Make sure your
 " plugins have sufficiently different names!
 function! maktaba#plugin#CanonicalName(plugin) abort
-  let l:plugin = a:plugin
-  if maktaba#string#StartsWith(l:plugin, 'vim-')
-    let l:plugin = l:plugin[4:]
-  endif
-  if maktaba#string#EndsWith(l:plugin, '.vim')
-    let l:plugin = l:plugin[:-5]
-  endif
-  return l:plugin
+  return matchstr(a:plugin, '\m\C^\(vim-\)\?\zs.\{-}\ze\(\.vim\)\?$')
 endfunction
 
 
@@ -396,7 +422,7 @@ function! maktaba#plugin#Get(name) abort
   endif
 
   " Check if any dir on runtimepath is a plugin that hasn't been detected yet.
-  for [l:leafdir, l:leafpath] in items(maktaba#rtp#LeafDirs())
+  for [l:leafdir, l:leafpath] in items(s:GetUnregisteredLeafdirs())
     if maktaba#plugin#CanonicalName(l:leafdir) is# l:name
       return maktaba#plugin#GetOrInstall(l:leafpath)
     endif

--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -114,12 +114,15 @@ endfunction
 ""
 " Gets a dictionary of {leaf path} for each path found on &rtp that does not
 " correspond to a registered plugin.
+" Returns the same data structure as maktaba#rtp#LeafDirs but with
+" already-registered dirs omitted.
 function! s:GetUnregisteredLeafdirs() abort
+  " NOTE: This function is performance-sensitive.
   let l:cache = s:unregistered_leafdirs_cache
   let l:plugin_locations = keys(s:plugins_by_location)
   if !has_key(l:cache, 'rtp') || !has_key(l:cache, 'plugin_locations') ||
       \ l:cache.rtp isnot# &rtp ||
-      \ l:cache.plugin_locations != l:plugin_locations
+      \ l:cache.plugin_locations !=# l:plugin_locations
     let l:leafdirs = {}
     for [l:leafdir, l:leafpath] in items(maktaba#rtp#LeafDirs())
       if !has_key(s:plugins_by_location, l:leafpath)
@@ -317,7 +320,7 @@ endfunction
 " registered with maktaba.
 function! maktaba#plugin#IsRegistered(plugin) abort
   try
-    let l:plugin = maktaba#plugin#Get(a:plugin)
+    call maktaba#plugin#Get(a:plugin)
   catch /ERROR(NotFound):/
     return 0
   endtry
@@ -336,7 +339,8 @@ endfunction
 " then maktaba can't handle a plugin named "plugins/myplugin". Make sure your
 " plugins have sufficiently different names!
 function! maktaba#plugin#CanonicalName(plugin) abort
-  return matchstr(a:plugin, '\m\C^\(vim-\)\?\zs.\{-}\ze\(\.vim\)\?$')
+  " NOTE: This function is performance-sensitive.
+  return matchstr(a:plugin, '\v\C^(vim-)?\zs.{-}\ze(\.vim)?$')
 endfunction
 
 


### PR DESCRIPTION
More performance optimizations in `maktaba#plugin#Get` and `maktaba#plugin#Detect` that help significantly when large numbers of plugins are installed.

Excerpts from my profiling results before and after:
```
 FUNCTION  maktaba#plugin#Get()                                                                       
 Called 101 times
-Total time:   0.261599                                                                              
+Total time:   0.075955                                                                              
- Self time:   0.025052                                                                              
+ Self time:   0.002005                                                                              

 count  total (s)   self (s)
-  101              0.000245   if has_key(s:plugins, a:name)                                         
+  101              0.000253   if has_key(s:plugins, a:name)                                         
-   53              0.000101     return s:plugins[a:name]                                            
+   53              0.000111     return s:plugins[a:name]                                            
                               endif                                                                 
                               
                               " If literal name didn't match, fall back to canonicalized name.      
-   48   0.003625   0.000187   let l:name = maktaba#plugin#CanonicalName(a:name)                     
+   48   0.000735   0.000209   let l:name = maktaba#plugin#CanonicalName(a:name)                     
-   48              0.000102   if has_key(s:plugins, l:name)                                         
+   48              0.000121   if has_key(s:plugins, l:name)                                         
                                 return s:plugins[l:name]                                            
                               endif                                                                 
                               
                               " Check if any dir on runtimepath is a plugin that hasn't been detected yet.
- 2467   0.065542   0.005727   for [l:leafdir, l:leafpath] in items(maktaba#rtp#LeafDirs())          
+   52   0.070776   0.000307   for [l:leafdir, l:leafpath] in items(s:GetUnregisteredLeafdirs())     
- 2419   0.180430   0.009802     if maktaba#plugin#CanonicalName(l:leafdir) is# l:name               
+    4   0.000075   0.000024     if maktaba#plugin#CanonicalName(l:leafdir) is# l:name               
                                   return maktaba#plugin#GetOrInstall(l:leafpath)                    
                                 endif                                                               
- 2419              0.001628   endfor                                                                
+    4              0.000004   endfor                                                                
                                                                                                     
-   48   0.410549   0.407883   throw maktaba#error#NotFound('Plugin %s', a:name)                     
+   48   0.420435   0.417531   throw maktaba#error#NotFound('Plugin %s', a:name)

 FUNCTION  maktaba#plugin#Detect()                                                                    
 Called 2 times                                                                                       
-Total time:   0.095049 
+Total time:   0.077732
- Self time:   0.000506
+ Self time:   0.000266
   
 count  total (s)   self (s)                                                                          
-   54   0.005388   0.000160   for [l:name, l:location] in items(maktaba#rtp#LeafDirs())             
+   28   0.005658   0.000088   for [l:name, l:location] in items(s:GetUnregisteredLeafdirs())        
-   52   0.089595   0.000280     call maktaba#plugin#GetOrInstall(l:location)                        
+   26   0.072038   0.000142     call maktaba#plugin#GetOrInstall(l:location)                        
-   52              0.000053   endfor                                                                
+   26              0.000024   endfor

 FUNCTION  maktaba#plugin#CanonicalName()                                                            
-Called 2553 times                                                                                   
+Called 138 times                                                                                    
-Total time:   0.180804                                                                              
+Total time:   0.001527                                                                              
- Self time:   0.039609                                                                              
+ Self time:   0.001527                                                                              
                                                                                                     
count  total (s)   self (s)                                                                          
- 2553              0.005094   let l:plugin = a:plugin                                               
- 2553   0.079972   0.008743   if maktaba#string#StartsWith(l:plugin, 'vim-')                        
-  196              0.000605     let l:plugin = l:plugin[4:]                                         
-  196              0.000155   endif                                                                 
- 2553   0.079005   0.009039   if maktaba#string#EndsWith(l:plugin, '.vim')                          
                                 let l:plugin = l:plugin[:-5]                                        
                               endif                                                                 
- 2553              0.002819   return l:plugin                                                       
+  138              0.001456   return matchstr(a:plugin, '\m\C^\(vim-\)\?\zs.\{-}\ze\(\.vim\)\?$')


 FUNCTIONS SORTED ON TOTAL TIME                                                                       
 count  total (s)   self (s)  function                                                                
-   43   0.329324   0.001078  maktaba#plugin#Install()                                               
+   43   0.334753   0.001524  maktaba#plugin#Install()                                               
-   70   0.262515   0.001064  maktaba#plugin#IsRegistered()                                          
+   70   0.076868   0.001078  maktaba#plugin#IsRegistered()                                          
-  101   0.261599   0.025052  maktaba#plugin#Get()
+  101   0.075955   0.002005  maktaba#plugin#Get()                                                   
- 2553   0.180804   0.039609  maktaba#plugin#CanonicalName()                                         
+  138   0.001527   0.001527  maktaba#plugin#CanonicalName()                                         
-  139   0.178332   0.010526  maktaba#plugin#GetOrInstall()
+  113   0.164122   0.009761  maktaba#plugin#GetOrInstall()                                          
-  436   0.135547   0.002472  maktaba#path#Dirname()
+  384   0.128307   0.003914  maktaba#path#Dirname()                                                 
-   14   0.102497   0.000187  maktaba#library#Require()                                              
+   14   0.057343   0.000198  maktaba#library#Require()                                              
-   14   0.102310   0.000391  maktaba#library#Import()
+   14   0.057145   0.000515  maktaba#library#Import()                                               
-    2   0.095049   0.000506  maktaba#plugin#Detect()
+    2   0.077732   0.000266  maktaba#plugin#Detect()                                                
-11036   0.085656   0.039748  maktaba#ensure#IsString()                                              
+  126   0.004832   0.002666  maktaba#ensure#IsString()                                              
- 2578   0.071922   0.031406  maktaba#string#StartsWith()                                            
+   25   0.001128   0.000520  maktaba#string#StartsWith()                                            
- 2553   0.069966   0.030707  maktaba#string#EndsWith()
-   52   0.068124   0.041983  maktaba#rtp#LeafDirs()
+   47   0.060565   0.036386  maktaba#rtp#LeafDirs()
```