### PR TITLE
Implement JSON parsing and formatting support in maktaba#json#

### DIFF
--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -1,0 +1,211 @@
+" Sentinel constants used to serialize/deserialize JSON primitives.
+if !exists('maktaba#json#NULL')
+  let maktaba#json#NULL = {'__json__': 'null'}
+  let s:NULL = maktaba#json#NULL
+  let maktaba#json#TRUE = {'__json__': 'true'}
+  let s:TRUE = maktaba#json#TRUE
+  let maktaba#json#FALSE = {'__json__': 'false'}
+  let s:FALSE = maktaba#json#FALSE
+  lockvar! maktaba#json#NULL maktaba#json#TRUE maktaba#json#FALSE
+endif
+
+function! s:Ellipsize(str, limit) abort
+  return len(a:str) > a:limit ? a:str[ : a:limit - 4] . '...' : a:str
+endfunction
+
+function! s:FormatKeyAndValue(key, value) abort
+  if maktaba#value#IsString(a:key)
+    return printf('"%s": %s', a:key, maktaba#json#Format(a:value))
+  endif
+  throw maktaba#error#BadValue(
+      \ 'Non-string keys not allowed for JSON dicts: %s.', string(a:key))
+endfunction
+
+""
+" Formats {value} as a JSON text.
+" {value} may be any Vim value other than a Funcref or non-finite Float (or a
+" Dictionary or List containing either).
+" @throws BadValue if the input cannot be represented as JSON.
+function! maktaba#json#Format(value) abort
+  if a:value is s:NULL
+    return 'null'
+  elseif a:value is s:TRUE
+    return 'true'
+  elseif a:value is s:FALSE
+    return 'false'
+  elseif maktaba#value#IsNumeric(a:value)
+    let l:json = string(a:value)
+    if index(['nan', 'inf', '-nan', '-inf'], l:json) != -1
+      throw maktaba#error#BadValue(
+          \ 'Value cannot be represented as JSON: %s', l:json)
+    endif
+    return l:json
+  elseif maktaba#value#IsString(a:value)
+    let l:escaped = substitute(escape(a:value, '"\'), "\n", '\\n', 'g')
+    let l:escaped = substitute(l:escaped, "\t", '\\t', 'g')
+    " TODO(dbarnett): Escape other special characters.
+    return '"' . l:escaped . '"'
+  elseif maktaba#value#IsList(a:value)
+    let l:json_items = map(copy(a:value), 'maktaba#json#Format(v:val)')
+    return '[' . join(l:json_items, ', ') . ']'
+  elseif maktaba#value#IsDict(a:value)
+    if maktaba#value#IsCallable(a:value)
+      throw maktaba#error#BadValue(
+          \ 'Funcdict for func %s cannot be represented as JSON.',
+          \ string(a:value.func))
+    endif
+    let l:json_items =
+        \ map(items(a:value), 's:FormatKeyAndValue(v:val[0], v:val[1])')
+    return '{' . join(l:json_items, ', ') . '}'
+  endif
+  throw maktaba#error#BadValue(a:value)
+endfunction
+
+function! s:Consume(str, count) abort
+  return maktaba#string#StripLeading(a:str[a:count : ])
+endfunction
+
+function! s:ParsePartial(json, custom_values) abort
+  " null, true, or false
+  if a:json =~# '\m^null\>'
+    let l:value = get(a:custom_values, 'null', s:NULL)
+    return [l:value, s:Consume(a:json, 4)]
+  endif
+  if a:json =~# '\m^true\>'
+    let l:value = get(a:custom_values, 'true', s:TRUE)
+    return [l:value, s:Consume(a:json, 4)]
+  endif
+  if a:json =~# '\m^false\>'
+    let l:value = get(a:custom_values, 'false', s:FALSE)
+    return [l:value, s:Consume(a:json, 5)]
+  endif
+  " Number
+  " TODO(dbarnett): Handle scientific notation.
+  let l:num_match = matchstr(a:json, '\v^-?[0-9]+(\.[0-9]+)?>')
+  if !empty(l:num_match)
+    return [eval(l:num_match), s:Consume(a:json, len(l:num_match))]
+  endif
+  " String
+  let l:str_match = matchstr(a:json, '\v^"([^\\"]|\\.)*"')
+  if !empty(l:str_match)
+    " JSON strings use the same syntax as JSON strings.
+    " TODO(dbarnett): Handle special escape sequences like \uxxxx.
+    let l:value = eval(l:str_match)
+    return [l:value, s:Consume(a:json, len(l:str_match))]
+  endif
+  " First character if any, empty string otherwise.
+  let l:first_char = a:json[0:0]
+  " List
+  if l:first_char is# '['
+    let [l:items, l:remaining] = s:ParseListPartial(a:json, a:custom_values)
+    return [l:items, l:remaining]
+  endif
+  " Dict
+  if l:first_char is# '{'
+    let [l:dict, l:remaining] = s:ParseDictPartial(a:json, a:custom_values)
+    return [l:dict, l:remaining]
+  endif
+  throw maktaba#error#BadValue('Input is not valid JSON text.')
+endfunction
+
+function! s:ParseListPartial(json, custom_values) abort
+  let l:remaining = s:Consume(a:json, 1)
+  if l:remaining[0:0] is# ']'
+    return [[], s:Consume(l:remaining, 1)]
+  endif
+  let l:items = []
+  while !empty(l:remaining)
+    " Parse and consume one value as the next list item.
+    let [l:item, l:remaining] = s:ParsePartial(l:remaining, a:custom_values)
+    call add(l:items, l:item)
+    " If next character is "]", consume and finish list.
+    if l:remaining[0:0] is# ']'
+      let l:remaining = s:Consume(l:remaining, 1)
+      break
+    endif
+    " Only other acceptable character is comma. Consume and continue.
+    if l:remaining[0:0] isnot# ','
+      throw maktaba#error#BadValue(
+          \ 'Junk after JSON array item: %s', s:Ellipsize(l:remaining, 30))
+    endif
+    let l:remaining = s:Consume(l:remaining, 1)
+  endwhile
+  return [l:items, l:remaining]
+endfunction
+
+function! s:ParseDictPartial(json, custom_values) abort
+  let l:remaining = s:Consume(a:json, 1)
+  if l:remaining[0:0] is# '}'
+    return [[], s:Consume(l:remaining, 1)]
+  endif
+  let l:dict = {}
+  while !empty(l:remaining)
+    " Parse and consume one value as the key.
+    let [l:key, l:remaining] = s:ParsePartial(l:remaining, a:custom_values)
+    if !maktaba#value#IsString(l:key)
+      throw maktaba#error#BadValue(
+          \ 'Non-string keys not allowed for JSON dicts: %s.', string(l:key))
+    endif
+    " Consume separating ":".
+    if l:remaining[0:0] isnot# ':'
+      throw maktaba#error#BadValue(
+          \ 'Junk after JSON key: %s', s:Ellipsize(l:remaining, 30))
+    endif
+    let l:remaining = s:Consume(l:remaining, 1)
+    " Parse and consume one value as the item value.
+    let [l:value, l:remaining] = s:ParsePartial(l:remaining, a:custom_values)
+    let l:dict[l:key] = l:value
+    unlet l:value
+
+    " If next character is "}", consume and finish list.
+    if l:remaining[0:0] is# '}'
+      let l:remaining = s:Consume(l:remaining, 1)
+      break
+    endif
+    " Only other acceptable character is comma. Consume and continue.
+    if l:remaining[0:0] isnot# ','
+      throw maktaba#error#BadValue(
+          \ 'Junk after JSON object item: %s', s:Ellipsize(l:remaining, 30))
+    endif
+    let l:remaining = s:Consume(l:remaining, 1)
+  endwhile
+  return [l:dict, l:remaining]
+endfunction
+
+function! s:SetDifference(a, b) abort
+  let l:difference = []
+  for l:a_item in a:a
+    if index(a:b, l:a_item) == -1
+      call add(l:difference, l:a_item)
+    endif
+  endfor
+  return l:difference
+endfunction
+
+""
+" Parses the JSON text {json} to a Vim value. If [custom_values] is passed, it
+" is a dictionary mapping JSON primitives (in string form) to custom values to
+" use instead of maktaba#json# sentinels. For example: >
+"   let value = maktaba#json#Parse('[null]', {'null': ''})
+" <
+" @throws WrongType if {json} is not a string or [custom_values] is not a dict.
+" @throws BadValue if {json} is not a valid JSON text.
+" @throws BadValue if [custom_value] keys are invalid JSON primitive names.
+function! maktaba#json#Parse(json, ...) abort
+  let l:json = maktaba#string#Strip(maktaba#ensure#IsString(a:json))
+  let l:custom_values = maktaba#ensure#IsDict(get(a:, 1, {}))
+  " Ensure custom values only has 'null', 'true', or 'false' as keys.
+  let l:allowed_custom_keys = ['null', 'true', 'false']
+  let l:unrecognized_custom_keys =
+      \ s:SetDifference(keys(l:custom_values), l:allowed_custom_keys)
+  if !empty(l:unrecognized_custom_keys)
+    throw maktaba#error#BadValue(
+        \ 'Invalid JSON primitive name(s) in custom_values: %s',
+        \ join(l:unrecognized_custom_keys, ', '))
+  endif
+  let [l:value, l:remaining] = s:ParsePartial(l:json, l:custom_values)
+  if empty(l:remaining)
+    return l:value
+  endif
+  throw maktaba#error#BadValue('Input is not valid JSON text.')
+endfunction

--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -190,7 +190,7 @@ endfunction
 " <
 " @throws WrongType if {json} is not a string or [custom_values] is not a dict.
 " @throws BadValue if {json} is not a valid JSON text.
-" @throws BadValue if [custom_value] keys are invalid JSON primitive names.
+" @throws BadValue if [custom_values] keys are invalid JSON primitive names.
 function! maktaba#json#Parse(json, ...) abort
   let l:json = maktaba#string#Strip(maktaba#ensure#IsString(a:json))
   let l:custom_values = maktaba#ensure#IsDict(get(a:, 1, {}))

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1043,8 +1043,7 @@ maktaba#json#Format({value})                           *maktaba#json#Format()*
   Funcref or non-finite Float (or a Dictionary or List containing either).
   Throws ERROR(BadValue) if the input cannot be represented as JSON.
 
-maktaba#json#Parse({json}, [custom_values], [custom_value])
-                                                        *maktaba#json#Parse()*
+maktaba#json#Parse({json}, [custom_values])             *maktaba#json#Parse()*
   Parses the JSON text {json} to a Vim value. If [custom_values] is passed, it
   is a dictionary mapping JSON primitives (in string form) to custom values to
   use instead of maktaba#json# sentinels. For example:
@@ -1054,7 +1053,7 @@ maktaba#json#Parse({json}, [custom_values], [custom_value])
   Throws ERROR(WrongType) if {json} is not a string or [custom_values] is not
   a dict.
   Throws ERROR(BadValue) if {json} is not a valid JSON text.
-  Throws ERROR(BadValue) if [custom_value] keys are invalid JSON primitive
+  Throws ERROR(BadValue) if [custom_values] keys are invalid JSON primitive
   names.
 
 maktaba#library#Import({library})                   *maktaba#library#Import()*

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1038,6 +1038,25 @@ maktaba#function#Sorted({list}, {func})            *maktaba#function#Sorted()*
   Returns a new list that is a sorted copy of {list}. {func} is used to
   determine the sort order, as in |sort()|.
 
+maktaba#json#Format({value})                           *maktaba#json#Format()*
+  Formats {value} as a JSON text. {value} may be any Vim value other than a
+  Funcref or non-finite Float (or a Dictionary or List containing either).
+  Throws ERROR(BadValue) if the input cannot be represented as JSON.
+
+maktaba#json#Parse({json}, [custom_values], [custom_value])
+                                                        *maktaba#json#Parse()*
+  Parses the JSON text {json} to a Vim value. If [custom_values] is passed, it
+  is a dictionary mapping JSON primitives (in string form) to custom values to
+  use instead of maktaba#json# sentinels. For example:
+>
+    let value = maktaba#json#Parse('[null]', {'null': ''})
+<
+  Throws ERROR(WrongType) if {json} is not a string or [custom_values] is not
+  a dict.
+  Throws ERROR(BadValue) if {json} is not a valid JSON text.
+  Throws ERROR(BadValue) if [custom_value] keys are invalid JSON primitive
+  names.
+
 maktaba#library#Import({library})                   *maktaba#library#Import()*
   Imports {library}.
 

--- a/vroom/json.vroom
+++ b/vroom/json.vroom
@@ -1,0 +1,120 @@
+Maktaba provides some simple functions to parse and format Vim values to JSON
+texts. These can parse and format numbers, strings, lists and dictionaries to
+their JSON equivalents.
+
+Currently, these functions depend upon access to Python, either via a version
+of Vim compiled with +python (or +python3), or by shelling out to the Python
+binary.
+
+As always, we start by installing Maktaba.
+
+  :set nocompatible
+  :let g:maktabadir = fnamemodify($VROOMFILE, ':p:h:h')
+  :let g:bootstrapfile = g:maktabadir . '/bootstrap.vim'
+  :execute 'source' g:bootstrapfile
+
+
+
+We can start by formatting a variety of Vim values as JSON. Any Vim value other
+than a Funcref can be formatted as a JSON text.
+
+  :function CheckEqual(a, b) abort
+  :  return maktaba#ensure#IsEqual(a:b, a:a)
+  :endfunction
+
+  :call CheckEqual(maktaba#json#Format('Hello, world'), '"Hello, world"')
+  :call CheckEqual(maktaba#json#Format(42), '42')
+  :call CheckEqual(maktaba#json#Format(42.0), '42.0')
+  :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1, 2, "foo"]')
+  :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
+  :call CheckEqual('{"foo": {"bar": "baz"}}', g:json)
+
+Note that all of these return a string.
+
+For strings, it properly escapes special characters like quote and newline.
+
+  :call CheckEqual(maktaba#json#Format("Foo'\"\nbar"), '"Foo''\"\nbar"')
+
+As Vim does not have a way of representing 'null' or the boolean values 'true',
+or 'false', these can be represented using sentinel values.
+
+  :call CheckEqual(maktaba#json#Format(maktaba#json#NULL), 'null')
+  :call CheckEqual(maktaba#json#Format(maktaba#json#TRUE), 'true')
+  :call CheckEqual(maktaba#json#Format(maktaba#json#FALSE), 'false')
+  :let g:json = maktaba#json#Format({'x': [maktaba#json#NULL, 1]})
+  :call CheckEqual(g:json, '{"x": [null, 1]}')
+
+
+
+We can also parse any given JSON text to a Vim value.
+
+  :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
+  :call CheckEqual(maktaba#json#Parse('42'), 42)
+  :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
+  :call CheckEqual(maktaba#json#Parse('[1, 2, "foo"]'), [1, 2, 'foo'])
+  :let g:dict = maktaba#json#Parse('{"foo": {"bar": "baz"}}')
+  :call CheckEqual(g:dict, {'foo': {'bar': 'baz'}})
+
+For strings, it properly interprets special characters like quote and newline.
+
+  :call CheckEqual(maktaba#json#Parse('"Foo''\"\nbar"'), "Foo'\"\nbar")
+
+Note that as Vim does not have a way of representing 'null' or the boolean
+values 'true', or 'false', these are normally represented as sentinel values.
+
+  :call CheckEqual(maktaba#json#Parse('null'), maktaba#json#NULL)
+  :call CheckEqual(maktaba#json#Parse('true'), maktaba#json#TRUE)
+  :call CheckEqual(maktaba#json#Parse('false'), maktaba#json#FALSE)
+  :let g:value = maktaba#json#Parse('[null, false]')
+  :call CheckEqual(g:value, [maktaba#json#NULL, maktaba#json#FALSE])
+  :let g:dict = maktaba#json#Parse('{"a": null, "b": true}')
+  :call CheckEqual(g:dict, {'a': maktaba#json#NULL, 'b': maktaba#json#TRUE})
+
+Since these sentinels may be inconvenient in some cases and it's hard to
+recursively replace them after the fact, maktaba#json#Parse provides a shortcut
+to replace these sentinels with any value you prefer in the returned value. Just
+pass a dictionary as the 2nd argument mapping primitives (in string form) to
+custom values.
+(In case you're wondering, string representations are used instead of the
+sentinels themselves since vimscript does not allow the sentinels to be used as
+dict keys.)
+
+  :call CheckEqual(maktaba#json#Parse('[null]', {'null': ''}), [''])
+
+Primitives that are not overridden will still be returned as sentinels.
+
+  :let g:dict = maktaba#json#Parse('{"a": true, "b": null}', {'true': 1})
+  :call CheckEqual(g:dict, {'a': 1, 'b': maktaba#json#NULL})
+
+This validates that your primitive names don't have typos.
+
+  :let g:parse = maktaba#function#Create('maktaba#json#Parse')
+  :call maktaba#error#Try(g:parse.WithArgs('', {'badname': ''}))
+  ~ ERROR(BadValue): Invalid JSON primitive name(s) in custom_values: badname
+
+
+
+Maktaba will throw an error if the input to maktaba#json#Parse() is not a
+string, or if it is not a valid JSON text.
+
+  :let g:parse = maktaba#function#Create('maktaba#json#Parse')
+  :call maktaba#error#Try(g:parse.WithArgs(0))
+  ~ ERROR(WrongType): Expected a string. Got a number.
+  :call maktaba#error#Try(g:parse.WithArgs('system("ls")'))
+  ~ ERROR(BadValue): Input is not valid JSON text.
+
+
+
+Maktaba will also throw an error if asked to format Vim values that cannot be
+represented in JSON.
+
+  :let g:nan = 0.0 / 0.0
+  :let g:inf = 1.0 / 0.0
+  :let g:format = maktaba#function#Create('maktaba#json#Format')
+  :call maktaba#error#Try(g:format.WithArgs(g:nan))
+  ~ ERROR\(BadValue\): Value cannot be represented as JSON: -?nan (regex)
+  :call maktaba#error#Try(g:format.WithArgs(g:inf))
+  ~ ERROR(BadValue): Value cannot be represented as JSON: inf
+
+  :call maktaba#error#Try(g:format.WithArgs(maktaba#function#Create('system')))
+  ~ ERROR(BadValue): Funcdict for func 'system' cannot be represented as JSON.

--- a/vroom/json.vroom
+++ b/vroom/json.vroom
@@ -18,8 +18,8 @@ As always, we start by installing Maktaba.
 We can start by formatting a variety of Vim values as JSON. Any Vim value other
 than a Funcref can be formatted as a JSON text.
 
-  :function CheckEqual(a, b) abort
-  :  return maktaba#ensure#IsEqual(a:b, a:a)
+  :function CheckEqual(actual, expected) abort
+  :  return maktaba#ensure#IsEqual(a:expected, a:actual)
   :endfunction
 
   :call CheckEqual(maktaba#json#Format('Hello, world'), '"Hello, world"')
@@ -27,7 +27,7 @@ than a Funcref can be formatted as a JSON text.
   :call CheckEqual(maktaba#json#Format(42.0), '42.0')
   :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1, 2, "foo"]')
   :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
-  :call CheckEqual('{"foo": {"bar": "baz"}}', g:json)
+  :call CheckEqual(g:json, '{"foo": {"bar": "baz"}}')
 
 Note that all of these return a string.
 


### PR DESCRIPTION
This implementation is not yet used for `maktaba#plugin#AddonInfo` because it adds a small but measurable delay to vim startup (~100ms out of ~800ms on my system). It should be fine as a non-python fallback, though, given the python implementation has good performance.

Fixes #35.