### PR TITLE
Add a Python implementation of JSON parsing and formatting functions.

### DIFF
--- a/autoload/maktaba.vim
+++ b/autoload/maktaba.vim
@@ -28,11 +28,6 @@ if !exists('s:maktaba')
   let s:maktaba.globals.loghandlers = maktaba#reflist#Create()
 endif
 
-if !exists('s:json_python_disabled')
-  let s:json_python_disabled = 0
-endif
-
-
 
 ""
 " Returns a handle to the maktaba plugin object.
@@ -109,23 +104,4 @@ function! maktaba#LateLoad(...) abort
   if l:cycle
     call maktaba#filetype#Cycle()
   endif
-endfunction
-
-
-""
-" @private
-" Forces the disabling of the Python implementation of the maktaba#json
-" functions, to enable testing. This must be called before referencing any of
-" the maktaba#json functions, since it will only take effect on first load.
-function! maktaba#SetJsonPythonDisabled(disabled) abort
-  let s:json_python_disabled = a:disabled
-endfunction
-
-
-""
-" @private
-" Returns whether the Python implementation of the maktaba#json functions is
-" disabled.
-function! maktaba#GetJsonPythonDisabled() abort
-  return s:json_python_disabled
 endfunction

--- a/autoload/maktaba.vim
+++ b/autoload/maktaba.vim
@@ -28,6 +28,11 @@ if !exists('s:maktaba')
   let s:maktaba.globals.loghandlers = maktaba#reflist#Create()
 endif
 
+if !exists('s:json_python_disabled')
+  let s:json_python_disabled = 0
+endif
+
+
 
 ""
 " Returns a handle to the maktaba plugin object.
@@ -104,4 +109,23 @@ function! maktaba#LateLoad(...) abort
   if l:cycle
     call maktaba#filetype#Cycle()
   endif
+endfunction
+
+
+""
+" @private
+" Forces the disabling of the Python implementation of the maktaba#json
+" functions, to enable testing. This must be called before referencing any of
+" the maktaba#json functions, since it will only take effect on first load.
+function! maktaba#SetJsonPythonDisabled(disabled) abort
+  let s:json_python_disabled = a:disabled
+endfunction
+
+
+""
+" @private
+" Returns whether the Python implementation of the maktaba#json functions is
+" disabled.
+function! maktaba#GetJsonPythonDisabled() abort
+  return s:json_python_disabled
 endfunction

--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -39,16 +39,15 @@ endfunction
 
 " Try to initialize Vim's Python environment. If that fails, we'll use the
 " Vimscript implementations instead.
-
-" maktaba#json#python#SetDisabled() can be used to skip trying to use the
+" maktaba#json#python#Disable() can be used to skip trying to use the
 " Python implementation.
-let s:disable_python = maktaba#json#python#GetDisabled()
+
 " We require Vim >= 7.3.1042 to use the Python implementation:
 "   7.3.569 added bindeval().
 "   7.3.996 added the vim.List and vim.Dictionary types.
 "   7.3.1042 fixes assigning a dict() containing Unicode keys to a Vim value.
 if v:version < 703 || (v:version == 703 && !has('patch1042'))
-      \ || s:disable_python
+      \ || maktaba#json#python#IsDisabled()
   let s:use_python = 0  " Not a recent Vim, or explicitly disabled
 else
   try

--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -1,3 +1,6 @@
+let s:plugin = maktaba#Maktaba()
+
+
 " Sentinel constants used to serialize/deserialize JSON primitives.
 if !exists('maktaba#json#NULL')
   let maktaba#json#NULL = {'__json__': 'null'}
@@ -14,114 +17,6 @@ endif
 
 " Python implementation:
 
-" Initialize Vim's Python environment with the helpers we'll need.
-function! s:InitPython() abort
-  python << EOF
-import json
-import vim
-
-
-def _maktaba_vim2py_deepcopy(value, null, true, false):
-    if isinstance(value, vim.List):
-        value = [_maktaba_vim2py_deepcopy(e, null, true, false)
-                 for e in value]
-    elif isinstance(value, vim.Dictionary):
-        # vim.Dictionary doesn't support items() or iter() until 7.3.1061.
-        value = {_maktaba_vim2py_deepcopy(k, null, true, false):
-                 _maktaba_vim2py_deepcopy(value[k], null, true, false)
-                 for k in value.keys()}
-
-    if value == null:
-        return None
-    if value == true:
-        return True
-    if value == false:
-        return False
-
-    return value
-
-
-def _maktaba_py2vim_scalar(value, null, true, false):
-    if value is None:
-        return null
-    if value is True:
-        return true
-    if value is False:
-        return false
-    return value
-
-
-def _maktaba_py2vim_list_inplace(value, null, true, false):
-    for i in range(len(value)):
-        v = value[i]
-        if isinstance(v, list):
-            _maktaba_py2vim_list_inplace(v, null, true, false)
-        elif isinstance(v, dict):
-            _maktaba_py2vim_dict_inplace(v, null, true, false)
-        else:
-            value[i] = _maktaba_py2vim_scalar(v, null, true, false)
-
-
-def _maktaba_py2vim_dict_inplace(value, null, true, false):
-    for k in value:
-        # JSON only permits string keys, so there's no need to transform the
-        # key, just the value.
-        v = value[k]
-        if isinstance(v, list):
-            _maktaba_py2vim_list_inplace(v, null, true, false)
-        elif isinstance(v, dict):
-            _maktaba_py2vim_dict_inplace(v, null, true, false)
-        else:
-            value[k] = _maktaba_py2vim_scalar(v, null, true, false)
-
-
-def maktaba_json_format():
-    buffer = vim.bindeval('l:buffer')
-    custom_values = buffer[0]
-    value = buffer[1]
-    # Now translate the Vim value to something that uses Python types (e.g.
-    # None, True, False), based on the custom values we're using.  Note that
-    # this must return a copy of the input, as we cannot store None (or True
-    # or False) in a Vim value.  (Doing that also avoids needing to tell
-    # json.dumps() how to serialize a vim.List or vim.Dictionary.)
-
-    # Note that to do this we need to check our custom values for equality,
-    # which we can't do if they're a vim.List or vim.Dictionary.
-    # Fortunately, there's an easy way to fix that.
-    custom_values = _maktaba_vim2py_deepcopy(custom_values, None, None, None)
-
-    # Now we can use those custom values to translate the real value.
-    value = _maktaba_vim2py_deepcopy(
-        value,
-        custom_values['null'], custom_values['true'], custom_values['false'])
-    try:
-      buffer[2] = json.dumps(value, allow_nan=False)
-    except ValueError as e:  # e.g. attempting to format NaN
-      buffer[3] = e.message
-    except TypeError as e:  # e.g. attempting to format a Function
-      buffer[3] = e.message
-
-
-def maktaba_json_parse():
-    buffer = vim.bindeval('l:buffer')
-
-    custom_values = buffer[0]
-    json_str = buffer[1]
-    try:
-      value = [json.loads(json_str)]
-    except ValueError as e:
-      buffer[3] = e.message
-      return
-
-    # Now mutate the resulting Python object to something that can be stored
-    # in a Vim value (i.e. has no None values, which Vim won't accept).
-    _maktaba_py2vim_list_inplace(
-        value,
-        custom_values['null'], custom_values['true'], custom_values['false'])
-    buffer[2] = value[0]
-EOF
-endfunction
-
 " Try to initialize Vim's Python environment. If that fails, we'll use the
 " Vimscript implementations instead.
 
@@ -137,7 +32,7 @@ if v:version < 703 || (v:version == 703 && !has('patch1042'))
   let s:use_python = 0  " Not a recent Vim, or explicitly disabled
 else
   try
-    call s:InitPython()
+    call maktaba#python#ImportModule(s:plugin, 'maktabajson')
     let s:use_python = 1
   catch /E319:/  " No +python
     let s:use_python = 0
@@ -147,7 +42,7 @@ endif
 " Python implementation of maktaba#json#Format()
 function! s:PythonFormat(value) abort
   let l:buffer = [s:DEFAULT_CUSTOM_VALUES, a:value, 0, 0]
-  python maktaba_json_format()
+  python maktabajson.format()
   if l:buffer[3] isnot# 0
     throw maktaba#error#BadValue(
         \ 'Value cannot be represented as JSON: %s.', l:buffer[3])
@@ -159,7 +54,7 @@ endfunction
 " Python implementation of s:ParsePartial()
 function! s:PythonParsePartial(json, custom_values) abort
   let l:buffer = [a:custom_values, a:json, 0, 0]
-  python maktaba_json_parse()
+  python maktabajson.parse()
   if l:buffer[3] isnot# 0
     throw maktaba#error#BadValue(
         \ 'Input is not valid JSON text: %s.', l:buffer[3])

--- a/autoload/maktaba/json/python.vim
+++ b/autoload/maktaba/json/python.vim
@@ -1,0 +1,29 @@
+if !exists('s:disable_python')
+  let s:disable_python = 0
+endif
+
+
+""
+" @private
+" Forces the disabling of the Python implementation of the maktaba#json
+" functions, to enable testing. This must be called before referencing any of
+" the maktaba#json functions, since it will only take effect on first load.
+function! maktaba#json#python#SetDisabled(disabled) abort
+  if islocked('s:disable_python')
+    call maktaba#error#Shout(
+       \ 'maktaba#json#python#SetDisabled() has no effect if called after '
+       \ . 'the first call to another maktaba#json function.')
+  else
+    let s:disable_python = a:disabled
+  endif
+endfunction
+
+
+""
+" @private
+" Returns whether the Python implementation of the maktaba#json functions is
+" disabled, and prevents further changes.
+function! maktaba#json#python#GetDisabled() abort
+  lockvar s:disable_python
+  return s:disable_python
+endfunction

--- a/autoload/maktaba/json/python.vim
+++ b/autoload/maktaba/json/python.vim
@@ -4,26 +4,27 @@ endif
 
 
 ""
-" @private
-" Forces the disabling of the Python implementation of the maktaba#json
-" functions, to enable testing. This must be called before referencing any of
-" the maktaba#json functions, since it will only take effect on first load.
-function! maktaba#json#python#SetDisabled(disabled) abort
+" Disables the Python implementation of the maktaba#json functions in favour
+" of the Vimscript implementations.  This is mostly intended for testing, but
+" can be used in the event of a problem with the Python implementation.
+"
+" This must be called before any of the other maktaba#json functions, since
+" the decision as to which implementation to use is made on first use.
+function! maktaba#json#python#Disable() abort
   if islocked('s:disable_python')
     call maktaba#error#Shout(
-       \ 'maktaba#json#python#SetDisabled() has no effect if called after '
-       \ . 'the first call to another maktaba#json function.')
+       \ 'maktaba#json#python#Disable() has no effect if called after the '
+       \ . 'first call to another maktaba#json function.')
   else
-    let s:disable_python = a:disabled
+    let s:disable_python = 1
   endif
 endfunction
 
 
 ""
-" @private
 " Returns whether the Python implementation of the maktaba#json functions is
 " disabled, and prevents further changes.
-function! maktaba#json#python#GetDisabled() abort
+function! maktaba#json#python#IsDisabled() abort
   lockvar s:disable_python
   return s:disable_python
 endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1056,6 +1056,18 @@ maktaba#json#Parse({json}, [custom_values])             *maktaba#json#Parse()*
   Throws ERROR(BadValue) if [custom_values] keys are invalid JSON primitive
   names.
 
+maktaba#json#python#Disable()                  *maktaba#json#python#Disable()*
+  Disables the Python implementation of the maktaba#json functions in favour
+  of the Vimscript implementations.  This is mostly intended for testing, but
+  can be used in the event of a problem with the Python implementation.
+
+  This must be called before any of the other maktaba#json functions, since
+  the decision as to which implementation to use is made on first use.
+
+maktaba#json#python#IsDisabled()            *maktaba#json#python#IsDisabled()*
+  Returns whether the Python implementation of the maktaba#json functions is
+  disabled, and prevents further changes.
+
 maktaba#library#Import({library})                   *maktaba#library#Import()*
   Imports {library}.
 

--- a/python/maktabajson.py
+++ b/python/maktabajson.py
@@ -1,0 +1,153 @@
+"""Python implementations of maktaba#json#Format() and maktaba#json#Parse().
+
+These will be used in place of the Vimscript implementations in recent versions
+of Vim (that are compiled with Python support), unless disabled using
+maktaba#SetJsonPythonDisabled().
+"""
+
+import json
+import vim
+
+
+def _vim2py_deepcopy(value, null, true, false):
+    """Return a deep copy of the given Vim value translated to Python types.
+
+    vim.List and vim.Dictionary values are recursively converted to Python list
+    and dict objects, respectively, and then all values are checked against the
+    'null', 'true', and 'false' (Python) sentinel values, which are converted
+    to None, True, and False, respectively.
+    """
+    if isinstance(value, vim.List):
+        value = [_vim2py_deepcopy(e, null, true, false)
+                 for e in value]
+    elif isinstance(value, vim.Dictionary):
+        # vim.Dictionary doesn't support items() or iter() until 7.3.1061.
+        value = {_vim2py_deepcopy(k, null, true, false):
+                 _vim2py_deepcopy(value[k], null, true, false)
+                 for k in value.keys()}
+
+    if value == null:
+        return None
+    if value == true:
+        return True
+    if value == false:
+        return False
+
+    return value
+
+
+def _py2vim_scalar(value, null, true, false):
+    """Return the given Python scalar translated to a Vim value.
+
+    None, True, and False are returned as the (Vim) sentinel values 'null',
+    'true', and 'false', respectively; anything else is returned untouched.
+    """
+    if value is None:
+        return null
+    if value is True:
+        return true
+    if value is False:
+        return false
+    return value
+
+
+def _py2vim_list_inplace(value, null, true, false):
+    """Convert all the values in the given Python list to Vim values,
+    recursively.
+    """
+    for i in range(len(value)):
+        v = value[i]
+        if isinstance(v, list):
+            _py2vim_list_inplace(v, null, true, false)
+        elif isinstance(v, dict):
+            _py2vim_dict_inplace(v, null, true, false)
+        else:
+            value[i] = _py2vim_scalar(v, null, true, false)
+
+
+def _py2vim_dict_inplace(value, null, true, false):
+    """Convert all the values (but not keys) in the given Python dict to Vim
+    values, recursively.
+    """
+    for k in value:
+        # JSON only permits string keys, so there's no need to transform the
+        # key, just the value.
+        v = value[k]
+        if isinstance(v, list):
+            _py2vim_list_inplace(v, null, true, false)
+        elif isinstance(v, dict):
+            _py2vim_dict_inplace(v, null, true, false)
+        else:
+            value[k] = _py2vim_scalar(v, null, true, false)
+
+
+def format():
+    """
+    Python implementation of maktaba#json#Format().
+
+    Arguments and return values are passed using a Vim list named 'l:buffer',
+    as follows:
+
+    l:buffer[0] - the mapping of null/true/false to the default Vim sentinels.
+    l:buffer[1] - the Vim value to format.
+    l:buffer[2] - (out) the string result.
+    l:buffer[3] - (out) the error message, if there is an error.
+    """
+
+    buffer = vim.bindeval('l:buffer')
+    custom_values = buffer[0]
+    value = buffer[1]
+    # Now translate the Vim value to something that uses Python types (e.g.
+    # None, True, False), based on the custom values we're using.  Note that
+    # this must return a copy of the input, as we cannot store None (or True
+    # or False) in a Vim value.  (Doing this also avoids needing to tell
+    # json.dumps() how to serialize a vim.List or vim.Dictionary.)
+
+    # Note that to do this we need to check our custom values for equality,
+    # which we also can't do if they're a vim.List or vim.Dictionary.
+    # Fortunately, there's an easy way to fix that.
+    custom_values = _vim2py_deepcopy(custom_values, None, None, None)
+
+    # Now we can use those custom values to translate the real value.
+    value = _vim2py_deepcopy(
+        value,
+        custom_values['null'], custom_values['true'], custom_values['false'])
+
+    try:
+        buffer[2] = json.dumps(value, allow_nan=False)
+    except ValueError as e:  # e.g. attempting to format NaN
+        buffer[3] = e.message
+    except TypeError as e:  # e.g. attempting to format a Function
+        buffer[3] = e.message
+
+
+def parse():
+    """
+    Python implementation of maktaba#json#Parse().
+
+    Arguments and return values are passed using a Vim list named 'l:buffer',
+    as follows:
+
+    l:buffer[0] - the mapping of null/true/false to the (possibly-custom) Vim
+                  values.
+    l:buffer[1] - the Vim string to parse.
+    l:buffer[2] - (out) the Vim value result.
+    l:buffer[3] - (out) the error message, if there is an error.
+    """
+    buffer = vim.bindeval('l:buffer')
+
+    custom_values = buffer[0]
+    json_str = buffer[1]
+    try:
+        value = [json.loads(json_str)]
+    except ValueError as e:
+        buffer[3] = e.message
+        return
+
+    # Now mutate the resulting Python object to something that can be stored
+    # in a Vim value (i.e. has no None values, which Vim won't accept).
+    _py2vim_list_inplace(
+        value,
+        custom_values['null'], custom_values['true'], custom_values['false'])
+
+    buffer[2] = value[0]

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -19,7 +19,7 @@ As always, we start by installing Maktaba.
 We then disable the Python implementations.  We must do this before we make any
 calls to a maktaba#json function.
 
-  :call maktaba#json#python#SetDisabled(1)
+  :call maktaba#json#python#Disable()
 
 
 

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -19,7 +19,7 @@ As always, we start by installing Maktaba.
 We then disable the Python implementations.  We must do this before we make any
 calls to a maktaba#json function.
 
-  :call maktaba#SetJsonPythonDisabled(1)
+  :call maktaba#json#python#SetDisabled(1)
 
 
 

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -6,8 +6,8 @@ These functions are provided in Vimscript and Python versions.  The Python
 versions are faster but depend upon a version of Vim compiled with +python
 (currently version 7.3.1042 or later).
 
-This set of tests uses the Python versions if available.  See
-json-vimscript.vroom for the tests of the Vimscript versions.
+This set of tests forces use of the Vimscript versions.  See json.vroom for the
+tests of the Python versions.
 
 As always, we start by installing Maktaba.
 
@@ -15,6 +15,11 @@ As always, we start by installing Maktaba.
   :let g:maktabadir = fnamemodify($VROOMFILE, ':p:h:h')
   :let g:bootstrapfile = g:maktabadir . '/bootstrap.vim'
   :execute 'source' g:bootstrapfile
+
+We then disable the Python implementations.  We must do this before we make any
+calls to a maktaba#json function.
+
+  :call maktaba#SetJsonPythonDisabled(1)
 
 
 
@@ -100,16 +105,13 @@ This validates that your primitive names don't have typos.
 
 
 Maktaba will throw an error if the input to maktaba#json#Parse() is not a
-string, or if it is not a valid JSON text.  Note that the precise text of the
-error may differ between the Vimscript and Python implementations, so we match
-against both below, in case we are running on a version of Vim that doesn't
-support the Python implementation.
+string, or if it is not a valid JSON text.
 
   :let g:parse = maktaba#function#Create('maktaba#json#Parse')
   :call maktaba#error#Try(g:parse.WithArgs(0))
   ~ ERROR(WrongType): Expected a string. Got a number.
   :call maktaba#error#Try(g:parse.WithArgs('system("ls")'))
-  ~ ERROR\(BadValue\): Input is not valid JSON text(.|:.*) (regex)
+  ~ ERROR(BadValue): Input is not valid JSON text.
 
 
 
@@ -120,11 +122,9 @@ represented in JSON.
   :let g:inf = 1.0 / 0.0
   :let g:format = maktaba#function#Create('maktaba#json#Format')
   :call maktaba#error#Try(g:format.WithArgs(g:nan))
-  ~ ERROR(BadValue): Value cannot be represented as JSON:* (glob)
+  ~ ERROR\(BadValue\): Value cannot be represented as JSON: -?nan (regex)
   :call maktaba#error#Try(g:format.WithArgs(g:inf))
-  ~ ERROR(BadValue): Value cannot be represented as JSON:* (glob)
+  ~ ERROR(BadValue): Value cannot be represented as JSON: inf
 
   :call maktaba#error#Try(g:format.WithArgs(maktaba#function#Create('system')))
-  ~ ERROR\(BadValue\): (regex)
-  |( Value cannot be represented as JSON:.*|
-  | Funcdict for func 'system' cannot be represented as JSON.)
+  ~ ERROR(BadValue): Funcdict for func 'system' cannot be represented as JSON.


### PR DESCRIPTION
Use Python's json library for `maktaba#json#Parse()` and `maktaba#json#Format()` where possible (if Vim is compiled with `+python`, and if we're using Vim >= 7.3.1042). This is both faster and more-correct.

Fixes #152.