### PR TITLE
Disable python use in Neovim

### DIFF
--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -48,6 +48,7 @@ endfunction
 "   7.3.1042 fixes assigning a dict() containing Unicode keys to a Vim value.
 if v:version < 703 || (v:version == 703 && !has('patch1042'))
       \ || maktaba#json#python#IsDisabled()
+      \ || has('nvim') " neovim does not implement bindeval, which maktaba uses.
   let s:use_python = 0  " Not a recent Vim, or explicitly disabled
 else
   try


### PR DESCRIPTION
This commit disables python in json module when running under Neovim.
Maktaba's maktabajson.py uses bindeval, which is not implemented in neovim and
causes error messages [Bug #158](https://github.com/google/vim-maktaba/issues/158).