### PR TITLE
Support JSON NaN and Infinity values for consistency w/ native

### DIFF
--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -189,8 +189,7 @@ function! s:ParsePartial(json, custom_values) abort
   endif
   " Special numbers (Infinity and NaN)
   if a:json =~# '\m^NaN\>'
-    " NOTE: Vim may represent this as negative (-nan).
-    return [0.0 / 0.0, s:Consume(a:json, 3)]
+    return [abs(0.0 / 0.0), s:Consume(a:json, 3)]
   endif
   if a:json =~# '\m^Infinity\>'
     return [1.0 / 0.0, s:Consume(a:json, 8)]

--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -1,7 +1,8 @@
 " Neovim support covered in https://github.com/neovim/neovim/issues/3417.
+" NOTE: Avoids using pre-1430 support for consistent Infinity/NaN.
 let s:HAS_NATIVE_JSON =
     \ !has('nvim') &&
-    \ v:version > 704 || v:version == 704 && has('patch1304')
+    \ v:version > 704 || v:version == 704 && has('patch1430')
 
 " Sentinel constants used to serialize/deserialize JSON primitives.
 if !exists('maktaba#json#NULL')
@@ -139,9 +140,12 @@ function! maktaba#json#Format(value) abort
     return 'false'
   elseif maktaba#value#IsNumeric(a:value)
     let l:json = string(a:value)
-    if index(['nan', 'inf', '-nan', '-inf'], l:json) != -1
-      throw maktaba#error#BadValue(
-          \ 'Value cannot be represented as JSON: %s', l:json)
+    if index(['nan', '-nan'], l:json) != -1
+      return 'NaN'
+    elseif l:json is# 'inf'
+      return 'Infinity'
+    elseif l:json is# '-inf'
+      return '-Infinity'
     endif
     return l:json
   elseif maktaba#value#IsString(a:value)
@@ -182,6 +186,17 @@ function! s:ParsePartial(json, custom_values) abort
   if a:json =~# '\m^false\>'
     let l:value = a:custom_values.false
     return [l:value, s:Consume(a:json, 5)]
+  endif
+  " Special numbers (Infinity and NaN)
+  if a:json =~# '\m^NaN\>'
+    " NOTE: Vim may represent this as negative (-nan).
+    return [0.0 / 0.0, s:Consume(a:json, 3)]
+  endif
+  if a:json =~# '\m^Infinity\>'
+    return [1.0 / 0.0, s:Consume(a:json, 8)]
+  endif
+  if a:json =~# '\m^-Infinity\>'
+    return [-1.0 / 0.0, s:Consume(a:json, 9)]
   endif
   " Number
   " TODO(dbarnett): Handle scientific notation.

--- a/python/maktabajson.py
+++ b/python/maktabajson.py
@@ -114,7 +114,7 @@ def format():
         custom_values['null'], custom_values['true'], custom_values['false'])
 
     try:
-        buffer[2] = json.dumps(value, allow_nan=False, separators=(',', ':'))
+        buffer[2] = json.dumps(value, allow_nan=True, separators=(',', ':'))
     except ValueError as e:  # e.g. attempting to format NaN
         buffer[3] = e.message
     except TypeError as e:  # e.g. attempting to format a Function

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -33,6 +33,9 @@ than a Funcref can be formatted as a JSON text.
   :call CheckEqual(maktaba#json#Format('Hello, world'), '"Hello, world"')
   :call CheckEqual(maktaba#json#Format(42), '42')
   :call CheckEqual(maktaba#json#Format(42.0), '42.0')
+  :call CheckEqual(maktaba#json#Format(0.0 / 0.0), 'NaN')
+  :call CheckEqual(maktaba#json#Format(1.0 / 0.0), 'Infinity')
+  :call CheckEqual(maktaba#json#Format(-1.0 / 0.0), '-Infinity')
   :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1,2,"foo"]')
   :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
   :call CheckEqual(g:json, '{"foo":{"bar":"baz"}}')
@@ -59,6 +62,10 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
+  :call maktaba#ensure#IsTrue(isnan(maktaba#json#Parse('NaN')))
+  :let g:inf = 1.0 / 0.0
+  :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
+  :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)
   :call CheckEqual(maktaba#json#Parse('[]'), [])
   :call CheckEqual(maktaba#json#Parse('[1,{},"foo"]'), [1, {}, 'foo'])
   :call CheckEqual(maktaba#json#Parse('{}'), {})
@@ -118,14 +125,7 @@ string, or if it is not a valid JSON text.
 Maktaba will also throw an error if asked to format Vim values that cannot be
 represented in JSON.
 
-  :let g:nan = 0.0 / 0.0
-  :let g:inf = 1.0 / 0.0
   :let g:format = maktaba#function#Create('maktaba#json#Format')
-  :call maktaba#error#Try(g:format.WithArgs(g:nan))
-  ~ ERROR\(BadValue\): Value cannot be represented as JSON: -?nan (regex)
-  :call maktaba#error#Try(g:format.WithArgs(g:inf))
-  ~ ERROR(BadValue): Value cannot be represented as JSON: inf
-
   :call maktaba#error#Try(g:format.WithArgs(maktaba#function#Create('system')))
   ~ ERROR\(BadValue\): (regex)
   |( Value cannot be represented as JSON:.*|

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -35,7 +35,8 @@ than a Funcref can be formatted as a JSON text.
   :call CheckEqual(maktaba#json#Format(42.0), '42.0')
   :call CheckEqual(maktaba#json#Format(0.0 / 0.0), 'NaN')
   :call CheckEqual(maktaba#json#Format(1.0 / 0.0), 'Infinity')
-  :call CheckEqual(maktaba#json#Format(-1.0 / 0.0), '-Infinity')
+  :call maktaba#ensure#IsIn(maktaba#json#Format(-1.0 / 0.0),
+  | ['-Infinity', 'Infinity'])
   :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1,2,"foo"]')
   :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
   :call CheckEqual(g:json, '{"foo":{"bar":"baz"}}')
@@ -62,11 +63,9 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
-  :let g:nan = 0.0 / 0.0
-  :call maktaba#ensure#IsIn(maktaba#json#Parse('NaN'), [g:nan, -g:nan])
+  :call CheckEqual(string(maktaba#json#Parse('NaN')), 'nan')
   :let g:inf = 1.0 / 0.0
   :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
-  :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)
   :call CheckEqual(maktaba#json#Parse('[]'), [])
   :call CheckEqual(maktaba#json#Parse('[1,{},"foo"]'), [1, {}, 'foo'])
   :call CheckEqual(maktaba#json#Parse('{}'), {})

--- a/vroom/json-vimscript.vroom
+++ b/vroom/json-vimscript.vroom
@@ -62,7 +62,8 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
-  :call maktaba#ensure#IsTrue(isnan(maktaba#json#Parse('NaN')))
+  :let g:nan = 0.0 / 0.0
+  :call maktaba#ensure#IsIn(maktaba#json#Parse('NaN'), [g:nan, -g:nan])
   :let g:inf = 1.0 / 0.0
   :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
   :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)

--- a/vroom/json.vroom
+++ b/vroom/json.vroom
@@ -57,7 +57,8 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
-  :call maktaba#ensure#IsTrue(isnan(maktaba#json#Parse('NaN')))
+  :let g:nan = 0.0 / 0.0
+  :call maktaba#ensure#IsIn(maktaba#json#Parse('NaN'), [g:nan, -g:nan])
   :let g:inf = 1.0 / 0.0
   :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
   :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)

--- a/vroom/json.vroom
+++ b/vroom/json.vroom
@@ -30,7 +30,8 @@ than a Funcref can be formatted as a JSON text.
   :call CheckEqual(maktaba#json#Format(42.0), '42.0')
   :call CheckEqual(maktaba#json#Format(0.0 / 0.0), 'NaN')
   :call CheckEqual(maktaba#json#Format(1.0 / 0.0), 'Infinity')
-  :call CheckEqual(maktaba#json#Format(-1.0 / 0.0), '-Infinity')
+  :call maktaba#ensure#IsIn(maktaba#json#Format(-1.0 / 0.0),
+  | ['-Infinity', 'Infinity'])
   :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1,2,"foo"]')
   :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
   :call CheckEqual(g:json, '{"foo":{"bar":"baz"}}')
@@ -57,11 +58,9 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
-  :let g:nan = 0.0 / 0.0
-  :call maktaba#ensure#IsIn(maktaba#json#Parse('NaN'), [g:nan, -g:nan])
+  :call CheckEqual(string(maktaba#json#Parse('NaN')), 'nan')
   :let g:inf = 1.0 / 0.0
   :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
-  :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)
   :call CheckEqual(maktaba#json#Parse('[]'), [])
   :call CheckEqual(maktaba#json#Parse('[1,{},"foo"]'), [1, {}, 'foo'])
   :call CheckEqual(maktaba#json#Parse('{}'), {})

--- a/vroom/json.vroom
+++ b/vroom/json.vroom
@@ -28,6 +28,9 @@ than a Funcref can be formatted as a JSON text.
   :call CheckEqual(maktaba#json#Format('Hello, world'), '"Hello, world"')
   :call CheckEqual(maktaba#json#Format(42), '42')
   :call CheckEqual(maktaba#json#Format(42.0), '42.0')
+  :call CheckEqual(maktaba#json#Format(0.0 / 0.0), 'NaN')
+  :call CheckEqual(maktaba#json#Format(1.0 / 0.0), 'Infinity')
+  :call CheckEqual(maktaba#json#Format(-1.0 / 0.0), '-Infinity')
   :call CheckEqual(maktaba#json#Format([1, 2, 'foo']), '[1,2,"foo"]')
   :let g:json = maktaba#json#Format({'foo': {'bar': 'baz'}})
   :call CheckEqual(g:json, '{"foo":{"bar":"baz"}}')
@@ -54,6 +57,10 @@ We can also parse any given JSON text to a Vim value.
   :call CheckEqual(maktaba#json#Parse('"Hello, world"'), 'Hello, world')
   :call CheckEqual(maktaba#json#Parse('42'), 42)
   :call CheckEqual(maktaba#json#Parse('42.0'), 42.0)
+  :call maktaba#ensure#IsTrue(isnan(maktaba#json#Parse('NaN')))
+  :let g:inf = 1.0 / 0.0
+  :call CheckEqual(maktaba#json#Parse('Infinity'), g:inf)
+  :call CheckEqual(maktaba#json#Parse('-Infinity'), -g:inf)
   :call CheckEqual(maktaba#json#Parse('[]'), [])
   :call CheckEqual(maktaba#json#Parse('[1,{},"foo"]'), [1, {}, 'foo'])
   :call CheckEqual(maktaba#json#Parse('{}'), {})
@@ -116,14 +123,7 @@ support the Python implementation.
 Maktaba will also throw an error if asked to format Vim values that cannot be
 represented in JSON.
 
-  :let g:nan = 0.0 / 0.0
-  :let g:inf = 1.0 / 0.0
   :let g:format = maktaba#function#Create('maktaba#json#Format')
-  :call maktaba#error#Try(g:format.WithArgs(g:nan))
-  ~ ERROR(BadValue): Value cannot be represented as JSON:* (glob)
-  :call maktaba#error#Try(g:format.WithArgs(g:inf))
-  ~ ERROR(BadValue): Value cannot be represented as JSON:* (glob)
-
   :call maktaba#error#Try(g:format.WithArgs(maktaba#function#Create('system')))
   ~ ERROR\(BadValue\): (regex)
   |( Value cannot be represented as JSON:.*|


### PR DESCRIPTION
Fixes #170.

Note I had to disable native support in the 1304–1429 range since there's no good way to build the new NaN/Infinity behavior on top of that implementation that errors out.