### PR TITLE
Fix IsCallable and IsEnum checking on 7.4.1875 and later

### DIFF
--- a/autoload/maktaba/enum.vim
+++ b/autoload/maktaba/enum.vim
@@ -38,7 +38,8 @@ endfunction
 function! maktaba#enum#IsValid(Value) abort
   return maktaba#value#IsDict(a:Value) &&
       \ has_key(a:Value, 'Name') &&
-      \ maktaba#value#IsEqual(a:Value.Name, function('maktaba#enum#Name'))
+      \ maktaba#function#HasSameName(
+          \ a:Value.Name, function('maktaba#enum#Name'))
 endfunction
 
 

--- a/autoload/maktaba/function.vim
+++ b/autoload/maktaba/function.vim
@@ -46,7 +46,25 @@ let s:DoWithContext = function('maktaba#function#DoWithContext')
 function! maktaba#function#IsWellFormedDict(F) abort
   return maktaba#value#IsDict(a:F)
       \ && has_key(a:F, 'Call')
-      \ && maktaba#value#IsEqual(a:F.Call, s:DoCall)
+      \ && maktaba#function#HasSameName(a:F.Call, s:DoCall)
+endfunction
+
+
+""
+" Checks whether Funcrefs {F} and {G} refer to the same function name.
+" Ignores bound arguments on partials, so the following check succeeds >
+"   let F = function('X')
+"   let G = function('X', [1])
+"   call maktaba#ensure#IsTrue(maktaba#function#HasSameName(F, G))
+" <
+" @throws WrongType if either arg not a Funcref.
+function! maktaba#function#HasSameName(F, G) abort
+  call maktaba#ensure#IsFuncref(a:F)
+  call maktaba#ensure#IsFuncref(a:G)
+  if has('patch-7.4.1875')
+    return get(a:F, 'name') ==# get(a:G, 'name')
+  endif
+  return a:F ==# a:G
 endfunction
 
 

--- a/autoload/maktaba/function.vim
+++ b/autoload/maktaba/function.vim
@@ -57,7 +57,7 @@ endfunction
 "   let G = function('X', [1])
 "   call maktaba#ensure#IsTrue(maktaba#function#HasSameName(F, G))
 " <
-" @throws WrongType if either arg not a Funcref.
+" @throws WrongType if either arg is not a Funcref.
 function! maktaba#function#HasSameName(F, G) abort
   call maktaba#ensure#IsFuncref(a:F)
   call maktaba#ensure#IsFuncref(a:G)

--- a/autoload/maktaba/value.vim
+++ b/autoload/maktaba/value.vim
@@ -63,14 +63,7 @@ endfunction
 " consistent with the behavior of equality established by |index()| and
 " |count()|, but may be surprising to some users.
 function! maktaba#value#IsEqual(X, Y) abort
-  if type(a:X) != type(a:Y)
-    return 0
-  endif
-  " NOTE: get(Funcref, 'name') fails without patch 1875.
-  return a:X ==# a:Y || (
-      \ has('patch-7.4.1875') &&
-      \ maktaba#value#IsFuncref(a:X) &&
-      \ get(a:X, 'name') ==# get(a:Y, 'name'))
+  return type(a:X) == type(a:Y) && a:X ==# a:Y
 endfunction
 
 

--- a/autoload/maktaba/value.vim
+++ b/autoload/maktaba/value.vim
@@ -65,25 +65,10 @@ function! s:FuncNamesEqual(X, Y) abort
     " Use simple equality. Partials were compared by name prior to patch 1875.
     return a:X == a:Y
   endif
-  " Compare functions by name only (ignoring everything after comma or paren).
-  " NOTE: This is robust without any clever handling of quotes and escapes
-  " because vim function names can't contain either special character.
+  " Compare functions by name only.
   return maktaba#value#IsFuncref(a:X) &&
       \ type(a:X) == type(a:Y) &&
-      \ s:FuncrefIdent(a:X) ==# s:FuncrefIdent(a:Y)
-endfunction
-
-
-""
-" Returns a truncated string representation of {X} which is unique to the
-" function name.
-" Example: >
-"   echo s:FuncrefIdent(function('X'))
-"   echo s:FuncrefIdent(function('X', [1], {'N': 2}))
-" <
-" These calls both return `"function('X'"`.
-function! s:FuncrefIdent(X) abort
-  return split(string(a:X), '\m[,)]', 1)[0]
+      \ get(a:X, 'name') ==# get(a:Y, 'name')
 endfunction
 
 

--- a/autoload/maktaba/value.vim
+++ b/autoload/maktaba/value.vim
@@ -62,6 +62,9 @@ endfunction
 " NOTE: {a} AND {b} MUST BE OF THE SAME TYPE. 1.0 DOES NOT EQUAL 1! This is
 " consistent with the behavior of equality established by |index()| and
 " |count()|, but may be surprising to some users.
+"
+" NOTE: Funcref comparison is by func name only prior to patch 7.4.1875 (any
+" partial of the same function name was considered equal).
 function! maktaba#value#IsEqual(X, Y) abort
   return type(a:X) == type(a:Y) && a:X ==# a:Y
 endfunction

--- a/autoload/maktaba/value.vim
+++ b/autoload/maktaba/value.vim
@@ -51,6 +51,43 @@ endfunction
 
 
 ""
+" Tests whether Funcrefs {X} and {Y} have the same function name.
+" This works around a behavior change in 7.4-1875 causing partials to not match
+" unless their argument lists match.
+" Example: >
+"   call s:FuncNamesEqual(
+"       \ function('X'),
+"       \ function('X', [1], {'N': 2}))
+" <
+" These functions compare as equal even though their arg bindings differ.
+function! s:FuncNamesEqual(X, Y) abort
+  if !has('patch-7.4.1875')
+    " Use simple equality. Partials were compared by name prior to patch 1875.
+    return a:X == a:Y
+  endif
+  " Compare functions by name only (ignoring everything after comma or paren).
+  " NOTE: This is robust without any clever handling of quotes and escapes
+  " because vim function names can't contain either special character.
+  return maktaba#value#IsFuncref(a:X) &&
+      \ type(a:X) == type(a:Y) &&
+      \ s:FuncrefIdent(a:X) ==# s:FuncrefIdent(a:Y)
+endfunction
+
+
+""
+" Returns a truncated string representation of {X} which is unique to the
+" function name.
+" Example: >
+"   echo s:FuncrefIdent(function('X'))
+"   echo s:FuncrefIdent(function('X', [1], {'N': 2}))
+" <
+" These calls both return `"function('X'"`.
+function! s:FuncrefIdent(X) abort
+  return split(string(a:X), '\m[,)]', 1)[0]
+endfunction
+
+
+""
 " Tests whether values {a} and {b} are equal.
 " This works around a number of limitations in vimscript's == operator. Unlike
 " with the == operator,
@@ -60,10 +97,10 @@ endfunction
 " The == operator is insane. Use this instead.
 "
 " NOTE: {a} AND {b} MUST BE OF THE SAME TYPE. 1.0 DOES NOT EQUAL 1! This is
-" consistent with the behavior of equality established by instant() and count(),
-" but may be surprising to some users.
+" consistent with the behavior of equality established by |index()| and
+" |count()|, but may be surprising to some users.
 function! maktaba#value#IsEqual(X, Y) abort
-  return type(a:X) == type(a:Y) && a:X ==# a:Y
+  return type(a:X) == type(a:Y) && ((a:X ==# a:Y) || s:FuncNamesEqual(a:X, a:Y))
 endfunction
 
 

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -871,7 +871,7 @@ maktaba#function#HasSameName({F}, {G})        *maktaba#function#HasSameName()*
     let G = function('X', [1])
     call maktaba#ensure#IsTrue(maktaba#function#HasSameName(F, G))
 <
-  Throws ERROR(WrongType) if either arg not a Funcref.
+  Throws ERROR(WrongType) if either arg is not a Funcref.
 
 maktaba#function#Create({func}, [arglist], [dict]) *maktaba#function#Create()*
   Creates a funcdict object that can be applied with
@@ -1643,6 +1643,9 @@ maktaba#value#IsEqual({a}, {b})                      *maktaba#value#IsEqual()*
   NOTE: {a} AND {b} MUST BE OF THE SAME TYPE. 1.0 DOES NOT EQUAL 1! This is
   consistent with the behavior of equality established by |index()| and
   |count()|, but may be surprising to some users.
+
+  NOTE: Funcref comparison is by func name only prior to patch 7.4.1875 (any
+  partial of the same function name was considered equal).
 
 maktaba#value#IsIn({value}, {list})                     *maktaba#value#IsIn()*
   Whether {value} is in {list}.

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1631,8 +1631,8 @@ maktaba#value#IsEqual({a}, {b})                      *maktaba#value#IsEqual()*
   The == operator is insane. Use this instead.
 
   NOTE: {a} AND {b} MUST BE OF THE SAME TYPE. 1.0 DOES NOT EQUAL 1! This is
-  consistent with the behavior of equality established by instant() and
-  count(), but may be surprising to some users.
+  consistent with the behavior of equality established by |index()| and
+  |count()|, but may be surprising to some users.
 
 maktaba#value#IsIn({value}, {list})                     *maktaba#value#IsIn()*
   Whether {value} is in {list}.

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -863,6 +863,16 @@ maktaba#flags#Create({name}, [default])               *maktaba#flags#Create()*
   initialized to [default].
   [default] is 0 if omitted.
 
+maktaba#function#HasSameName({F}, {G})        *maktaba#function#HasSameName()*
+  Checks whether Funcrefs {F} and {G} refer to the same function name. Ignores
+  bound arguments on partials, so the following check succeeds
+>
+    let F = function('X')
+    let G = function('X', [1])
+    call maktaba#ensure#IsTrue(maktaba#function#HasSameName(F, G))
+<
+  Throws ERROR(WrongType) if either arg not a Funcref.
+
 maktaba#function#Create({func}, [arglist], [dict]) *maktaba#function#Create()*
   Creates a funcdict object that can be applied with
   |maktaba#function#Apply()|. When applied, {func} will be applied with


### PR DESCRIPTION
~~Modifies maktaba#value#IsEqual to work around a behavior change in
7.4.1875…~~
Switches code in IsCallable an IsEnum to explicitly check if Funcrefs have the same name using explicit `maktaba#function#HasSameName` helper. `maktaba#value#IsEqual` behavior stays the same, meaning it will have slightly different behavior when patch 1875 is present.

Fixes #172.