### PR TITLE
Fix path#Basename handling for bare filenames (was always empty string)

### DIFF
--- a/autoload/maktaba/path.vim
+++ b/autoload/maktaba/path.vim
@@ -46,13 +46,13 @@ function! s:SplitLast(path) abort
     let l:count += 1
   endwhile
 
-  " Return [HEAD, TAIL] with root (if any_ included in the HEAD.
+  " Return [HEAD, TAIL] with root (if any) included in the HEAD.
   if l:last_sep != -1
     " Slice up to (but not including) separator as HEAD.
     let l:head = l:last_sep > 0 ? l:path[ : l:last_sep - 1] : ''
     return [l:root . l:head, l:path[l:last_sep + 1 : ]]
   else
-    return [l:root, '']
+    return [l:root, l:path]
   endif
 endfunction
 
@@ -172,6 +172,12 @@ endfunction
 "   :echomsg maktaba#path#Basename('/path/to/dir/')
 " <
 " The first echoes 'file', the second echoes ''.
+"
+" A bare filename is its own basename:
+" >
+"   :echomsg maktaba#path#Basename('file')
+" <
+" This echoes 'file'.
 function! maktaba#path#Basename(path) abort
   return s:SplitLast(a:path)[1]
 endfunction
@@ -183,7 +189,13 @@ endfunction
 "   :echomsg maktaba#path#Dirname('/path/to/file')
 "   :echomsg maktaba#path#Dirname('/path/to/dir/')
 " <
-" The first echoes '/path/to', the second echoes '/path/to/dir'
+" The first echoes '/path/to', the second echoes '/path/to/dir'.
+"
+" A bare filename with no slashes returns an empty dirname:
+" >
+"   :echomsg maktaba#path#Dirname('file')
+" <
+" This echoes ''.
 function! maktaba#path#Dirname(path) abort
   return s:SplitLast(a:path)[0]
 endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1227,13 +1227,25 @@ maktaba#path#Basename({path})                        *maktaba#path#Basename()*
 <
   The first echoes 'file', the second echoes ''.
 
+  A bare filename is its own basename:
+>
+    :echomsg maktaba#path#Basename('file')
+<
+  This echoes 'file'.
+
 maktaba#path#Dirname({path})                          *maktaba#path#Dirname()*
   The dirname of {path}. Trailing slash matters. Consider:
 >
     :echomsg maktaba#path#Dirname('/path/to/file')
     :echomsg maktaba#path#Dirname('/path/to/dir/')
 <
-  The first echoes '/path/to', the second echoes '/path/to/dir'
+  The first echoes '/path/to', the second echoes '/path/to/dir'.
+
+  A bare filename with no slashes returns an empty dirname:
+>
+    :echomsg maktaba#path#Dirname('file')
+<
+  This echoes ''.
 
 maktaba#path#GetDirectory({path})                *maktaba#path#GetDirectory()*
   Gets the directory path of {path}. If {path} appears to point to a file, the

--- a/vroom/path.vroom
+++ b/vroom/path.vroom
@@ -97,6 +97,8 @@ the last component of the path:
   ~ 'file'
   :echomsg string(maktaba#path#Basename('/path/to/dir/'))
   ~ ''
+  :echomsg string(maktaba#path#Basename('file'))
+  ~ 'file'
 
 Dirname gets all but the last components of the path (in path form, without a
 trailing slash):
@@ -105,6 +107,8 @@ trailing slash):
   ~ '/path/to'
   :echomsg string(maktaba#path#Dirname('/path/to/dir/'))
   ~ '/path/to/dir'
+  :echomsg string(maktaba#path#Dirname('file'))
+  ~ ''
 
 For both utilities, callers are encouraged to use canonical dir representation
 (with a trailing slash) for directory paths, to disambiguate them from file


### PR DESCRIPTION
This was apparently a regression in 5021b3f from years ago. Note Dirname behavior was correct in itself, but it broke the invariant that `Join([Dirname(X), Basename(X)])` should be equivalent to the original path `X`.

Fixes #177.