### PR TITLE
Add support for Syscall.CallAsync callback that doesn't accept env_dict

### DIFF
--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -457,23 +457,11 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
   Throws ERROR(WrongType)
   Throws ERROR(ShellError) if the shell command returns a non-zero exit code.
 
-Syscall.CallAsync({callback}, {allow_sync_fallback}, [pass_env])
-                                                         *Syscall.CallAsync()*
+Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   Executes the system call asynchronously and invokes {callback} on
-  completion. If {allow_sync_fallback} is 1 and async calls are not available,
-  a synchronous call will be executed and callback called with the result.
-
-  [pass_env] specifies the signature of {callback}.
-  If it is 0 (recommended), {callback} will be called with a single argument:
+  completion. {callback} function will be called with the following arguments:
   {callback}(result_dict), where result_dict contains stdout, stderr and
-  status (code).
-  If it is 1 (legacy default) or omitted, {callback} will be called with two
-  arguments: {callback}(env_dict, result_dict), where env_dict contains tab,
-  buffer, path, column and line info, and the result_dict contains stdout,
-  stderr and status (code). Future maktaba changes will remove this mode, and
-  eventually remove the param entirely.
-
-  For example:
+  status (code). For example:
 >
     function Handler(result) abort
       if a:result.status != 0
@@ -482,7 +470,7 @@ Syscall.CallAsync({callback}, {allow_sync_fallback}, [pass_env])
       endif
       echomsg 'Success!'
     endfunction
-    call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1, 0)
+    call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
 <
   WARNING: The callback is responsible for checking result_dict.status and
   handling unexpected exit codes. Otherwise all failures are silent.
@@ -502,8 +490,12 @@ Syscall.CallAsync({callback}, {allow_sync_fallback}, [pass_env])
     let callback = maktaba#function#Create('ReplaceLineHandler', [env])
     call maktaba#syscall#Create(['date']).CallAsync(callback, 1, 0)
 <
-  This pattern replaces the legacy [pass_env] mechanism, but is more explicit
-  and more flexible.
+
+  As a legacy fallback, if the callback fails expecting more arguments, it
+  will be called with the arguments: {callback}(env_dict, result_dict), where
+  env_dict contains tab, buffer, path, column and line info, and the
+  result_dict contains stdout, stderr and status (code). This fallback will be
+  deprecated and stop working in future versions of maktaba.
 
   Asynchronous calls are executed via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -457,26 +457,53 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
   Throws ERROR(WrongType)
   Throws ERROR(ShellError) if the shell command returns a non-zero exit code.
 
-Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
+Syscall.CallAsync({callback}, {allow_sync_fallback}, [pass_env])
+                                                         *Syscall.CallAsync()*
   Executes the system call asynchronously and invokes {callback} on
-  completion. {callback} function will be called with the following arguments:
-  {callback}(env_dict, result_dict), where env_dict contains tab, buffer,
-  path, column and line info, and the result_dict contains stdout, stderr and
-  status (code). If {allow_sync_fallback} is 1 and async calls are not
-  available, a synchronous call will be executed and callback called with the
-  result. For example:
+  completion. If {allow_sync_fallback} is 1 and async calls are not available,
+  a synchronous call will be executed and callback called with the result.
+
+  [pass_env] specifies the signature of {callback}.
+  If it is 0 (recommended), {callback} will be called with a single argument:
+  {callback}(result_dict), where result_dict contains stdout, stderr and
+  status (code).
+  If it is 1 (legacy default) or omitted, {callback} will be called with two
+  arguments: {callback}(env_dict, result_dict), where env_dict contains tab,
+  buffer, path, column and line info, and the result_dict contains stdout,
+  stderr and status (code). Future maktaba changes will remove this mode, and
+  eventually remove the param entirely.
+
+  For example:
 >
-    function Handler(env_dict, result)
+    function Handler(result) abort
       if a:result.status != 0
         call maktaba#error#Shout('sleep command failed: %s', a:result.stderr)
         return
       endif
       echomsg 'Success!'
     endfunction
-    call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
+    call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1, 0)
 <
-  WARNING: The caller is responsible for checking result_dict.status and
+  WARNING: The callback is responsible for checking result_dict.status and
   handling unexpected exit codes. Otherwise all failures are silent.
+
+  NOTE: If {callback} depends on cursor location or other vim state, the
+  caller should capture parameters and bind them to the callback:
+>
+    function ReplaceLineHandler(env, result) abort
+      if a:result.status != 0
+        call maktaba#error#Shout('date call failed: %s', a:result.stderr)
+        return
+      endif
+      execute 'buffer' a:env.buffer
+      call maktaba#buffer#Overwrite(a:env.line, a:env.line, [a:result.stdout])
+    endfunction
+    let env = {'buffer': bufnr('%'), 'line': line('.')}
+    let callback = maktaba#function#Create('ReplaceLineHandler', [env])
+    call maktaba#syscall#Create(['date']).CallAsync(callback, 1, 0)
+<
+  This pattern replaces the legacy [pass_env] mechanism, but is more explicit
+  and more flexible.
 
   Asynchronous calls are executed via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -370,8 +370,7 @@ maktaba#system#Or to chain commands.
 To execute system calls asynchronously, use CallAsync.
 
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
-  :function Callback(env, return_data) abort<CR>
-  |  let g:env = a:env<CR>
+  :function Callback(return_data) abort<CR>
   |  let g:callback_stdout = a:return_data.stdout<CR>
   |  let g:callback_exit_code = a:return_data.status<CR>
   |endfunction
@@ -388,7 +387,6 @@ To execute system calls asynchronously, use CallAsync.
 Asynchronous calls can also take a stdin parameter.
 
   :unlet g:callback_stdout
-  :unlet g:env
   :unlet g:callback_exit_code
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
   :call g:syscall.CallAsync('Callback', 0)
@@ -407,5 +405,18 @@ Async calls fall back to synchronous calls if disabled or not available.
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
   :call g:syscall.CallAsync('Callback', 1)
   ! echo hi 2> .*
+
+As a legacy fallback, if the callback fails expecting more arguments, it will be
+called with the arguments: {callback}(env_dict, result_dict).
+
+  :function! Callback(env, return_data) abort<CR>
+  |  let g:env = a:env<CR>
+  |  let g:callback_stdout = a:return_data.stdout<CR>
+  |  let g:callback_exit_code = a:return_data.status<CR>
+  |endfunction
+  :call g:syscall.CallAsync('Callback', 1)
+  ! echo hi 2> .*
+  :echomsg string(sort(keys(g:env)))
+  ~ ['buffer', 'column', 'line', 'path', 'tab']
 
   @system


### PR DESCRIPTION
Simplify the Syscall.CallAsync interface. This removes the `env_dict` arg from the callback, but still supports the old signature during a deprecation period as a legacy fallback.

I've found the callback signature confusing in practice, and upcoming CallAsync enhancements will make CallAsync more viable and potentially add a lot more usage, so now's the time to get any migrations underway.

Fixes #180.

@stgpetrovic