### PR TITLE
Change Syscall.CallAsync to return an explicit SyscallInvocation.

### DIFF
--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -2,8 +2,8 @@
 
 let s:plugin = maktaba#Maktaba()
 
-if !exists('s:callbacks')
-  let s:callbacks = {}
+if !exists('s:pending_invocations')
+  let s:pending_invocations = {}
 endif
 
 if !exists('s:async_disabled')
@@ -78,17 +78,6 @@ function! s:DoSyscallCommon(syscall, CallFunc, throw_errors) abort
 endfunction
 
 
-" Compiles a dictionary describing the current vim state.
-function! s:CurrentEnv()
-  return {
-      \ 'tab': tabpagenr(),
-      \ 'buffer': bufnr('%'),
-      \ 'path': expand('%:p'),
-      \ 'column': col('.'),
-      \ 'line': line('.')}
-endfunction
-
-
 ""
 " @private
 " @dict Syscall
@@ -126,20 +115,19 @@ endfunction
 " Calls |system()| asynchronously, and invokes a @function(this.callback) once
 " the command completes, passing in stdout, stderr and exit code to it.
 " The specific implementation for @function(#CallAsync).
-function! maktaba#syscall#DoCallAsync() abort dict
-  let l:error_file = tempname()
-  let l:output_file = tempname()
-  let l:callback_cmd = join([
+function! maktaba#syscall#DoCallAsync(invocation) abort dict
+  let a:invocation._outfile = tempname()
+  let a:invocation._errfile = tempname()
+  let l:callback_cmd = [
       \ v:progname,
       \ '--servername ' . v:servername,
       \ '--remote-expr',
-      \ printf('"maktaba#syscall#AsyncDone(''%s'', ''%s'', $?)"',
-            \ l:output_file, l:error_file)], " ")
+      \ printf('"maktaba#syscall#AsyncDone(%d, $?)"', a:invocation.id)]
   let l:full_cmd = printf('(%s; %s >/dev/null) > %s 2> %s &',
-      \ self.GetCommand(), l:callback_cmd, l:output_file, l:error_file)
-  let s:callbacks[l:output_file] = {
-      \ 'function': maktaba#ensure#IsCallable(self.callback),
-      \ 'env': s:CurrentEnv()}
+      \ self.GetCommand(),
+      \ join(l:callback_cmd, ' '),
+      \ a:invocation._outfile,
+      \ a:invocation._errfile)
 
   if has_key(self, 'stdin')
     call system(l:full_cmd, self.stdin)
@@ -279,9 +267,16 @@ endfunction
 ""
 " @dict Syscall
 " Executes the system call asynchronously and invokes {callback} on completion.
-" {callback} function will be called with the following arguments:
-" {callback}(result_dict), where result_dict contains stdout, stderr and status
-" (code).
+" If vim implementation does not support async execution (details below),
+" setting {allow_sync_fallback} allows the system call to be executed
+" synchronously as a fallback instead of failing with an error.
+"
+" Returns a @dict(SyscallInvocation) to interact with the invocation, check
+" status, etc.
+"
+" {callback} function will be called with the SyscallInvocation as an argument,
+" as {callback}(SyscallInvocation), and the invocation provides access to
+" stdout, stderr and status (code).
 " For example: >
 "   function Handler(result) abort
 "     if a:result.status != 0
@@ -292,8 +287,8 @@ endfunction
 "   endfunction
 "   call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
 " <
-" WARNING: The callback is responsible for checking result_dict.status and
-" handling unexpected exit codes. Otherwise all failures are silent.
+" WARNING: The callback is responsible for checking SyscallInvocation.status and
+" handling unexpected exit codes. Otherwise all syscall failures are silent.
 "
 " NOTE: If {callback} depends on cursor location or other vim state, the caller
 " should capture parameters and bind them to the callback: >
@@ -311,10 +306,9 @@ endfunction
 " <
 "
 " As a legacy fallback, if the callback fails expecting more arguments, it will
-" be called with the arguments: {callback}(env_dict, result_dict), where
-" env_dict contains tab, buffer, path, column and line info, and the result_dict
-" contains stdout, stderr and status (code). This fallback will be deprecated
-" and stop working in future versions of maktaba.
+" be called with the arguments: {callback}(env_dict, SyscallInvocation), where
+" env_dict contains tab, buffer, path, column and line info. This fallback will
+" be deprecated and stop working in future versions of maktaba.
 "
 " Asynchronous calls are executed via |--remote-expr| using vim's |clientserver|
 " capabilities, so the preconditions for it are vim being compiled with
@@ -327,8 +321,9 @@ endfunction
 " @throws WrongType
 " @throws MissingFeature if neither async execution nor fallback is available.
 function! maktaba#syscall#CallAsync(Callback, allow_sync_fallback) abort dict
-  let self.callback = maktaba#ensure#IsCallable(a:Callback)
   call maktaba#ensure#IsBool(a:allow_sync_fallback)
+  let l:invocation = maktaba#syscall#invocation#Create(
+      \ maktaba#ensure#IsCallable(a:Callback))
   if !maktaba#syscall#IsAsyncAvailable()
     if a:allow_sync_fallback
       call s:plugin.logger.Warn('Async support not available. ' .
@@ -336,17 +331,8 @@ function! maktaba#syscall#CallAsync(Callback, allow_sync_fallback) abort dict
           \ self.GetCommand())
       let l:return_data = self.Call(0)
       let l:return_data.status = v:shell_error
-      try
-        " Try prototype callback({result_dict}).
-        call maktaba#function#Call(self.callback, [l:return_data])
-      catch /E119:/
-        " Not enough arguments.
-        " Fall back to legacy prototype callback({env_dict}, {result_dict}).
-        " TODO(#180): Deprecate and shout an error for this case.
-        call maktaba#function#Call(
-            \ self.callback, [s:CurrentEnv(), l:return_data])
-      endtry
-      return
+      call l:invocation.Finish(l:return_data)
+      return l:invocation
     else
       " Neither async nor sync is available. Throw error with salient reason.
       if s:async_disabled
@@ -366,8 +352,9 @@ function! maktaba#syscall#CallAsync(Callback, allow_sync_fallback) abort dict
     endif
   endif
 
+  let s:pending_invocations[l:invocation.id] = l:invocation
   let l:call_func = maktaba#function#Create(
-      \ 'maktaba#syscall#DoCallAsync', [], self)
+      \ 'maktaba#syscall#DoCallAsync', [l:invocation], self)
   " Errors indicate a problem with the CallAsync implementation, so they're
   " thrown as ERROR(Failure) and not expected to be caught by callers.
   try
@@ -376,7 +363,10 @@ function! maktaba#syscall#CallAsync(Callback, allow_sync_fallback) abort dict
     throw maktaba#error#Failure('Problem dispatching async syscall: %s',
         \ maktaba#error#Split(v:exception)[1])
   endtry
+
+  return l:invocation
 endfunction
+
 
 ""
 " @dict Syscall
@@ -447,29 +437,18 @@ endfunction
 
 ""
 " @private
-" Executes the asynchronous callback setup by @function(Syscall.CallAsync).
-" The callback must be of prototype: callback(result_dict) or legacy prototype
-" callback(env_dict, result_dict). The latter will be deprecated and stop
-" working in future versions of maktaba.
-function! maktaba#syscall#AsyncDone(stdout_file, stderr_file, exit_code)
-  let l:callback_info = s:callbacks[a:stdout_file]
-  let l:return_data = {}
-  let l:return_data.status = a:exit_code
-  let l:return_data.stdout = join(readfile(a:stdout_file), "\n")
-  if filereadable(a:stderr_file)
-    let l:return_data.stderr = join(readfile(a:stderr_file), "\n")
-    call delete(a:stderr_file)
+" Marks the SyscallInvocation associated with {invocation_id} finished with
+" given {exit_code} and executes its callback.
+function! maktaba#syscall#AsyncDone(invocation_id, exit_code)
+  let l:invocation = s:pending_invocations[a:invocation_id]
+  unlet s:pending_invocations[a:invocation_id]
+  let result_dict = {
+      \ 'status': a:exit_code,
+      \ 'stdout': join(readfile(l:invocation._outfile), "\n")}
+  call delete(l:invocation._outfile)
+  if filereadable(l:invocation._errfile)
+    let l:result_dict.stderr = join(readfile(l:invocation._errfile), "\n")
+    call delete(l:invocation._errfile)
   endif
-  unlet s:callbacks[a:stdout_file]
-  call delete(a:stdout_file)
-  try
-    " Try prototype callback({result_dict}).
-    call maktaba#function#Call(l:callback_info.function, [l:return_data])
-  catch /E119:/
-    " Not enough arguments.
-    " Fall back to legacy prototype callback({env_dict}, {result_dict}).
-    " TODO(#180): Deprecate and shout an error for this case.
-    call maktaba#function#Call(
-        \ l:callback_info.function, [l:callback_info.env, l:return_data])
-  endtry
+  call l:invocation.Finish(l:result_dict)
 endfunction

--- a/autoload/maktaba/syscall/invocation.vim
+++ b/autoload/maktaba/syscall/invocation.vim
@@ -27,20 +27,21 @@ endfunction
 " status, etc.
 "
 " Public variables:
-" * finished: 0 if invocation is pending, 1 if finished. The result variables
-"   (status, stdout, stderr) will not exist if invocation is not finished.
+" * finished: 0 if the invocation is pending, 1 if finished. The result
+"   variables (status, stdout, stderr) will not exist if the invocation is not
+"   finished.
 "   Guaranteed to be 1 when an invocation's callback is called.
 " * status: the shell exit code from the invocation (typically 0 for success).
 " * stdout: the invocation's entire stdout string.
 " * stderr: the invocation's entire stderr string, if available.
 "
-" Note one Syscall invoked multiple times would produce multiple independent
-" SyscallInvocations.
+" Note that one Syscall invoked multiple times would produce multiple
+" independent SyscallInvocations.
 
 
 ""
 " @private
-" Create a @dict(SyscallInvocation).
+" Creates a @dict(SyscallInvocation).
 " Private helper only for use by Syscall.CallAsync.
 function! maktaba#syscall#invocation#Create(Callback) abort
   return {

--- a/autoload/maktaba/syscall/invocation.vim
+++ b/autoload/maktaba/syscall/invocation.vim
@@ -1,0 +1,90 @@
+if !exists('s:num_invocations')
+  let s:num_invocations = 0
+endif
+
+""
+" Gets a number uniquely identifying a SyscallInvocation.
+function! s:CreateInvocationId()
+  let s:num_invocations += 1
+  return s:num_invocations
+endfunction
+
+" Compiles a dictionary describing the current vim state.
+function! s:CurrentEnv()
+  return {
+      \ 'tab': tabpagenr(),
+      \ 'buffer': bufnr('%'),
+      \ 'path': expand('%:p'),
+      \ 'column': col('.'),
+      \ 'line': line('.')}
+endfunction
+
+
+""
+" @dict SyscallInvocation
+" A maktaba representation of a single invocation of a @dict(Syscall).
+" Provides a mechanism for interacting with a syscall invocation, checking
+" status, etc.
+"
+" Public variables:
+" * finished: 0 if invocation is pending, 1 if finished. The result variables
+"   (status, stdout, stderr) will not exist if invocation is not finished.
+"   Guaranteed to be 1 when an invocation's callback is called.
+" * status: the shell exit code from the invocation (typically 0 for success).
+" * stdout: the invocation's entire stdout string.
+" * stderr: the invocation's entire stderr string, if available.
+"
+" Note one Syscall invoked multiple times would produce multiple independent
+" SyscallInvocations.
+
+
+""
+" @private
+" Create a @dict(SyscallInvocation).
+" Private helper only for use by Syscall.CallAsync.
+function! maktaba#syscall#invocation#Create(Callback) abort
+  return {
+      \ 'id': s:CreateInvocationId(),
+      \ 'finished': 0,
+      \ '_env': s:CurrentEnv(),
+      \ '_callback': a:Callback,
+      \ '_TriggerCallback':
+          \ function('maktaba#syscall#invocation#TriggerCallback'),
+      \ 'Finish': function('maktaba#syscall#invocation#Finish')}
+endfunction
+
+
+""
+" @private
+" Executes the invocation's callback. The callback must be of prototype:
+" callback(result_dict) or legacy prototype callback(env_dict, result_dict).
+" The latter will be deprecated and stop working in future versions of maktaba.
+function! maktaba#syscall#invocation#TriggerCallback() abort dict
+  try
+    " Try prototype callback({result_dict}).
+    call maktaba#function#Call(self._callback, [self])
+  catch /E119:/
+    " Not enough arguments.
+    " Fall back to legacy prototype callback({env_dict}, {result_dict}).
+    " TODO(#180): Deprecate and shout an error for this case.
+    call maktaba#function#Call(self._callback, [self._env, self])
+  endtry
+endfunction
+
+
+""
+" @private
+" @dict SyscallInvocation
+" Executes the asynchronous callback setup by @function(Syscall.CallAsync).
+" The callback must be of prototype: callback(result_dict) or legacy prototype
+" callback(env_dict, result_dict). The latter will be deprecated and stop
+" working in future versions of maktaba.
+function! maktaba#syscall#invocation#Finish(result) abort dict
+  let self.status = a:result.status
+  let self.stdout = a:result.stdout
+  if has_key(a:result, 'stderr')
+    let self.stderr = a:result.stderr
+  endif
+  let self.finished = 1
+  call self._TriggerCallback()
+endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -459,9 +459,9 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
 
 Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   Executes the system call asynchronously and invokes {callback} on
-  completion. If vim implementation does not support async execution (details
-  below), setting {allow_sync_fallback} allows the system call to be executed
-  synchronously as a fallback instead of failing with an error.
+  completion. If the current vim instance does not support async execution
+  (details below), setting {allow_sync_fallback} allows the system call to be
+  executed synchronously as a fallback instead of failing with an error.
 
   Returns a |maktaba.SyscallInvocation| to interact with the invocation, check
   status, etc.
@@ -541,15 +541,15 @@ Provides a mechanism for interacting with a syscall invocation, checking
 status, etc.
 
 Public variables:
-  * finished: 0 if invocation is pending, 1 if finished. The result variables
-    (status, stdout, stderr) will not exist if invocation is not finished.
-    Guaranteed to be 1 when an invocation's callback is called.
+  * finished: 0 if the invocation is pending, 1 if finished. The result
+    variables (status, stdout, stderr) will not exist if the invocation is not
+    finished. Guaranteed to be 1 when an invocation's callback is called.
   * status: the shell exit code from the invocation (typically 0 for success).
   * stdout: the invocation's entire stdout string.
   * stderr: the invocation's entire stderr string, if available.
 
-Note one Syscall invoked multiple times would produce multiple independent
-SyscallInvocations.
+Note that one Syscall invoked multiple times would produce multiple
+independent SyscallInvocations.
 
 ==============================================================================
 FUNCTIONS                                                  *maktaba-functions*

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -459,9 +459,16 @@ Syscall.Call([throw_errors])                                  *Syscall.Call()*
 
 Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   Executes the system call asynchronously and invokes {callback} on
-  completion. {callback} function will be called with the following arguments:
-  {callback}(result_dict), where result_dict contains stdout, stderr and
-  status (code). For example:
+  completion. If vim implementation does not support async execution (details
+  below), setting {allow_sync_fallback} allows the system call to be executed
+  synchronously as a fallback instead of failing with an error.
+
+  Returns a |maktaba.SyscallInvocation| to interact with the invocation, check
+  status, etc.
+
+  {callback} function will be called with the SyscallInvocation as an
+  argument, as {callback}(SyscallInvocation), and the invocation provides
+  access to stdout, stderr and status (code). For example:
 >
     function Handler(result) abort
       if a:result.status != 0
@@ -472,8 +479,9 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
     endfunction
     call maktaba#syscall#Create(['sleep', '3']).CallAsync('Handler', 1)
 <
-  WARNING: The callback is responsible for checking result_dict.status and
-  handling unexpected exit codes. Otherwise all failures are silent.
+  WARNING: The callback is responsible for checking SyscallInvocation.status
+  and handling unexpected exit codes. Otherwise all syscall failures are
+  silent.
 
   NOTE: If {callback} depends on cursor location or other vim state, the
   caller should capture parameters and bind them to the callback:
@@ -492,10 +500,9 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
 <
 
   As a legacy fallback, if the callback fails expecting more arguments, it
-  will be called with the arguments: {callback}(env_dict, result_dict), where
-  env_dict contains tab, buffer, path, column and line info, and the
-  result_dict contains stdout, stderr and status (code). This fallback will be
-  deprecated and stop working in future versions of maktaba.
+  will be called with the arguments: {callback}(env_dict, SyscallInvocation),
+  where env_dict contains tab, buffer, path, column and line info. This
+  fallback will be deprecated and stop working in future versions of maktaba.
 
   Asynchronous calls are executed via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being
@@ -527,6 +534,22 @@ Syscall.GetCommand()                                    *Syscall.GetCommand()*
   Gets the literal command string that would be executed by |Syscall.Call()|
   or |Syscall.CallForeground()|, with words joined and special characters
   escaped.
+
+                                                   *maktaba.SyscallInvocation*
+A maktaba representation of a single invocation of a |maktaba.Syscall|.
+Provides a mechanism for interacting with a syscall invocation, checking
+status, etc.
+
+Public variables:
+  * finished: 0 if invocation is pending, 1 if finished. The result variables
+    (status, stdout, stderr) will not exist if invocation is not finished.
+    Guaranteed to be 1 when an invocation's callback is called.
+  * status: the shell exit code from the invocation (typically 0 for success).
+  * stdout: the invocation's entire stdout string.
+  * stderr: the invocation's entire stderr string, if available.
+
+Note one Syscall invoked multiple times would produce multiple independent
+SyscallInvocations.
 
 ==============================================================================
 FUNCTIONS                                                  *maktaba-functions*

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -369,50 +369,48 @@ maktaba#system#Or to chain commands.
 
 To execute system calls asynchronously, use CallAsync.
 
-  :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
-  :function Callback(return_data) abort<CR>
-  |  let g:callback_stdout = a:return_data.stdout<CR>
-  |  let g:callback_exit_code = a:return_data.status<CR>
+  :function AsyncWait(invocation, delay) abort<CR>
+  |  let l:deadline = localtime() + a:delay " wait for at most N seconds<CR>
+  |  while !a:invocation.finished && localtime() < l:deadline<CR>
+  |  endwhile<CR>
+  |  call maktaba#ensure#IsTrue(a:invocation.finished,
+  | 'Async callback was expected to complete within %d seconds', a:delay)<CR>
+  |  return a:invocation<CR>
   |endfunction
-  :call g:syscall.CallAsync('Callback', 0)
+  :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
+  :function Callback(result) abort<CR>
+  |  let g:callback_stdout = a:result.stdout<CR>
+  |endfunction
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
   ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
-  :let g:deadline = localtime() + 2 " wait for at most 2 seconds
-  :while !exists('g:callback_exit_code') && localtime() < g:deadline
-  :endwhile
-  :call maktaba#ensure#IsTrue(exists('g:callback_exit_code'),
-  | 'Async callback was expected to complete within 2 seconds')
   :echomsg g:callback_stdout
+  ~ hi
+  :echomsg g:invocation.stdout
   ~ hi
 
 Asynchronous calls can also take a stdin parameter.
 
   :unlet g:callback_stdout
-  :unlet g:callback_exit_code
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
-  :call g:syscall.CallAsync('Callback', 0)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
   ! .*cat; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
-  :let g:deadline = localtime() + 2 " wait for at most 2 seconds
-  :while !exists('g:callback_exit_code') && localtime() < g:deadline
-  :endwhile
-  :call maktaba#ensure#IsTrue(exists('g:callback_exit_code'),
-  | 'Async callback was expected to complete within 2 seconds')
-  :echomsg g:callback_stdout
+  :echomsg g:invocation.stdout
   ~ Hello
 
 Async calls fall back to synchronous calls if disabled or not available.
 
   :call maktaba#syscall#SetAsyncDisabled(1)
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
-  :call g:syscall.CallAsync('Callback', 1)
+  :let g:invocation = g:syscall.CallAsync('Callback', 1)
   ! echo hi 2> .*
+  :echomsg g:invocation.stdout
+  ~ hi
 
 As a legacy fallback, if the callback fails expecting more arguments, it will be
 called with the arguments: {callback}(env_dict, result_dict).
 
-  :function! Callback(env, return_data) abort<CR>
+  :function! Callback(env, result) abort<CR>
   |  let g:env = a:env<CR>
-  |  let g:callback_stdout = a:return_data.stdout<CR>
-  |  let g:callback_exit_code = a:return_data.status<CR>
   |endfunction
   :call g:syscall.CallAsync('Callback', 1)
   ! echo hi 2> .*


### PR DESCRIPTION
Returns a SyscallInvocation dict from CallAsync calls that encapsulates
the invocation's status and output. This can be extended in future
changes to allow other types of interactions. It's also passed into the
callbacks (backwards-compatible with the result_dict value), so if other
data needs to be passed into callbacks in the future it can be attached
to the invocation.