### PR TITLE
Notify user for messages logged at WARN or above by default.

### DIFF
--- a/autoload/maktaba/log.vim
+++ b/autoload/maktaba/log.vim
@@ -87,10 +87,13 @@ endfunction
 
 
 ""
-" Sets the minimum {level} that will be immediately shown to the user using
-" @function(maktaba#error#Warn) or @function(maktaba#error#Shout). The
-" notification level defaults to WARN if it was never explicitly configured.
-" If {level} is -1, notifications will be disabled entirely.
+" Sets the minimum {level} of log messages that will trigger a user
+" notification, or -1 to disable notifications. By default, the user will be
+" notified after every message logged at WARN or higher.
+"
+" Notifications will be sent using @function(maktaba#error#Shout) for ERROR
+" and SEVERE messages, @function(maktaba#error#Warn) for WARN, and |:echomsg|
+" for INFO and DEBUG.
 " @throws BadValue
 function! maktaba#log#SetNotificationLevel(level) abort
   call maktaba#ensure#IsTrue(

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1193,10 +1193,13 @@ maktaba#list#RemoveAll({list}, {item})              *maktaba#list#RemoveAll()*
   returned for convenience.
 
 maktaba#log#SetNotificationLevel({level}) *maktaba#log#SetNotificationLevel()*
-  Sets the minimum {level} that will be immediately shown to the user using
-  |maktaba#error#Warn()| or |maktaba#error#Shout()|. The notification level
-  defaults to WARN if it was never explicitly configured. If {level} is -1,
-  notifications will be disabled entirely.
+  Sets the minimum {level} of log messages that will trigger a user
+  notification, or -1 to disable notifications. By default, the user will be
+  notified after every message logged at WARN or higher.
+
+  Notifications will be sent using |maktaba#error#Shout()| for ERROR and
+  SEVERE messages, |maktaba#error#Warn()| for WARN, and |:echomsg| for INFO
+  and DEBUG.
   Throws ERROR(BadValue)
 
 maktaba#log#Logger({context})                           *maktaba#log#Logger()*

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1192,6 +1192,13 @@ maktaba#list#RemoveAll({list}, {item})              *maktaba#list#RemoveAll()*
   Removes all instances of {item} from {list}. {list} is modified in place and
   returned for convenience.
 
+maktaba#log#SetNotificationLevel({level}) *maktaba#log#SetNotificationLevel()*
+  Sets the minimum {level} that will be immediately shown to the user using
+  |maktaba#error#Warn()| or |maktaba#error#Shout()|. The notification level
+  defaults to WARN if it was never explicitly configured. If {level} is -1,
+  notifications will be disabled entirely.
+  Throws ERROR(BadValue)
+
 maktaba#log#Logger({context})                           *maktaba#log#Logger()*
   Creates a |maktaba.Logger| interface for {context}.
 

--- a/vroom/log.vroom
+++ b/vroom/log.vroom
@@ -27,8 +27,26 @@ the usual Debug, Info, Warn, Error, and Severe functions:
   :call g:vroom_logger.Debug('why')
   :call g:vroom_logger.Info('hello')
   :call g:vroom_logger.Warn('there')
+  ~ [VROOMFILE] there
   :call g:vroom_logger.Error('my')
+  ~ [VROOMFILE] my
   :call g:vroom_logger.Severe('friend')
+  ~ [VROOMFILE] friend
+
+By default, messages logged at WARN or above are also shown immediately to the
+user. Call maktaba#log#SetNotificationLevel to configure a different level.
+
+  :let g:LEVELS = maktaba#log#LEVELS
+  :call maktaba#log#SetNotificationLevel(g:LEVELS.SEVERE)
+  :call g:vroom_logger.Error('Threepio! Where could he be?!')
+  :call g:vroom_logger.Severe('Shut down all the garbage mashers!!')
+  ~ [VROOMFILE] Shut down all the garbage mashers!!
+
+Setting the display level to -1 disables printing these log messages completely.
+
+  :call maktaba#log#SetNotificationLevel(-1)
+  :call g:vroom_logger.Severe('Shut down all the garbage mashers!!')
+
 
 Each plugin gets a logger attached automatically for its context:
 
@@ -43,7 +61,6 @@ On the consumption side of things, maktaba provides maktaba#log, a simple
 callback-based API for log viewing plugins to subscribe to log messages as they
 arrive.
 
-  :let g:LEVELS = maktaba#log#LEVELS
   :function LogHandler(level, timestamp, context, message) abort
   :  echomsg printf('Log message: %s %s [%s] %s', g:LEVELS.Name(a:level),
   | string(a:timestamp), a:context, a:message)
@@ -60,7 +77,7 @@ logged earlier...
   ~ Log message: WARN [0-9]+ \[VROOMFILE\] there (regex)
   ~ Log message: ERROR [0-9]+ \[VROOMFILE\] my (regex)
   ~ Log message: SEVERE [0-9]+ \[VROOMFILE\] friend (regex)
-
+  ~ .* (regex)
   ~ Log message: DEBUG [0-9]+ \[emptyplugin\] Hello from emptyplugin (regex)
 
 New messages are logged as they arrive.


### PR DESCRIPTION
Notifies at WARN level by default, and adds a `maktaba#log#SetNotificationLevel` hook to override that level.

Fixes #185.

Note: Any pre-existing callers and handlers that print log messages may trigger duplicate notifications until those are cleaned up. In cases where avoiding that is particularly important, they can detect whether `maktaba#log#SetNotificationLevel` exists.