### PR TITLE
Add vim job support to Syscall.CallAsync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - sudo dpkg -i ./vroom_0.12.0-1_all.deb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
-  - vroom $VROOM_ARGS --crawl
+  - vroom $VROOM_ARGS --crawl --skip=vroom/system-vimjob.vroom
 matrix:
   fast_finish: true
   allow_failures:

--- a/autoload/maktaba/syscall/async.vim
+++ b/autoload/maktaba/syscall/async.vim
@@ -61,6 +61,7 @@ endfunction
 " @private
 " @dict SyscallVimjobInvocation
 function! maktaba#syscall#async#HandleJobExit(unused_job, status) abort dict
+  " NOTE: Stdout & stderr are joined w/o newline separator since IO mode is raw.
   call self._invocation.Finish({
       \ 'status': a:status,
       \ 'stdout': join(self._stdout, ''),

--- a/autoload/maktaba/syscall/async.vim
+++ b/autoload/maktaba/syscall/async.vim
@@ -1,0 +1,68 @@
+" CallAsync implementation using vim's job support.
+
+""
+" @private
+function! maktaba#syscall#async#CreateInvocation(syscall, invocation) abort
+  return {
+      \ '_syscall': a:syscall,
+      \ '_invocation': a:invocation,
+      \ '_stdout': [],
+      \ '_stderr': [],
+      \ 'Start': function('maktaba#syscall#async#Start'),
+      \ 'HandleStdout': function('maktaba#syscall#async#HandleStdout'),
+      \ 'HandleStderr': function('maktaba#syscall#async#HandleStderr'),
+      \ 'HandleJobExit': function('maktaba#syscall#async#HandleJobExit')}
+endfunction
+
+
+""
+" @private
+" @dict SyscallVimjobInvocation
+" Dispatches syscall through |job_start()|, and invokes the invocation's
+" callback once the command completes, passing in stdout, stderr and exit code
+" to it.
+" The vim job implementation for @function(#CallAsync).
+function! maktaba#syscall#async#Start() abort dict
+  " NOTE: Doesn't need to override &shell since it's not used by job_start().
+  let self._job = job_start(self._syscall.GetCommand(), {
+      \ 'out_mode': 'raw',
+      \ 'err_mode': 'raw',
+      \ 'out_cb': self.HandleStdout,
+      \ 'err_cb': self.HandleStderr,
+      \ 'exit_cb': self.HandleJobExit})
+  let l:channel = job_getchannel(self._job)
+  " Send stdin immediately and close. Streaming input to stdin not supported.
+  if has_key(self._syscall, 'stdin')
+    call ch_sendraw(l:channel, self._syscall.stdin)
+  endif
+  call ch_close_in(l:channel)
+endfunction
+
+
+""
+" @private
+" @dict SyscallVimjobInvocation
+function! maktaba#syscall#async#HandleStdout(unused_channel, message)
+    \ abort dict
+  call add(self._stdout, a:message)
+endfunction
+
+
+""
+" @private
+" @dict SyscallVimjobInvocation
+function! maktaba#syscall#async#HandleStderr(unused_channel, message)
+    \ abort dict
+  call add(self._stderr, a:message)
+endfunction
+
+
+""
+" @private
+" @dict SyscallVimjobInvocation
+function! maktaba#syscall#async#HandleJobExit(unused_job, status) abort dict
+  call self._invocation.Finish({
+      \ 'status': a:status,
+      \ 'stdout': join(self._stdout, ''),
+      \ 'stderr': join(self._stderr, '')})
+endfunction

--- a/autoload/maktaba/syscall/clientserver.vim
+++ b/autoload/maktaba/syscall/clientserver.vim
@@ -1,0 +1,104 @@
+" Legacy clientserver CallAsync support.
+" TODO(#190): Remove this implementation.
+
+if !exists('s:num_invocations')
+  let s:num_invocations = 0
+endif
+
+if !exists('s:pending_invocations')
+  let s:pending_invocations = {}
+endif
+
+""
+" Gets a number uniquely identifying a SyscallInvocation.
+function! s:CreateInvocationId()
+  let s:num_invocations += 1
+  return s:num_invocations
+endfunction
+
+
+""
+" @private
+function! maktaba#syscall#clientserver#CreateInvocation(syscall, invocation)
+    \ abort
+  return {
+      \ '_id': s:CreateInvocationId(),
+      \ '_syscall': a:syscall,
+      \ '_invocation': a:invocation,
+      \ 'Start': function('maktaba#syscall#clientserver#Start'),
+      \ 'Finish': function('maktaba#syscall#clientserver#Finish')}
+endfunction
+
+
+""
+" @private
+" Marks the SyscallInvocation associated with {id} finished with given
+" {exit_code} and executes its callback.
+function! maktaba#syscall#clientserver#FinishInvocation(id, exit_code) abort
+  try
+    try
+      let l:invocation = s:pending_invocations[a:id]
+    catch /E716:/
+      " Key not present.
+      call maktaba#error#Shout(
+          \ 'CallAsync error: No pending invocation found with ID %d.',
+          \ a:id)
+      return
+    endtry
+    unlet s:pending_invocations[a:id]
+    call l:invocation.Finish(a:exit_code)
+  catch
+    " Uncaught errors from here would be sent back to the --remote-expr command
+    " line, but vim can't do anything useful with them from there. Catch and
+    " shout them here instead.
+    call maktaba#error#Shout('Error from CallAsync callback: %s', v:exception)
+  endtry
+endfunction
+
+
+""
+" @private
+" @dict SyscallClientServerInvocation
+" Calls |system()| asynchronously, and invokes the invocation's callback once
+" the command completes, passing in stdout, stderr and exit code to it.
+" The legacy clientserver implementation for @function(#CallAsync).
+" Returns empty dict for convenience, to satisfy DoSyscallCommon signature.
+function! maktaba#syscall#clientserver#Start() abort dict
+  let self._outfile = tempname()
+  let self._errfile = tempname()
+  let l:callback_cmd = [
+      \ v:progname,
+      \ '--servername ' . v:servername,
+      \ '--remote-expr',
+      \ printf('"maktaba#syscall#clientserver#FinishInvocation(%d, $?)"',
+          \ self._id)]
+  let l:full_cmd = printf('(%s; %s >/dev/null) > %s 2> %s &',
+      \ self._syscall.GetCommand(),
+      \ join(l:callback_cmd, ' '),
+      \ self._outfile,
+      \ self._errfile)
+
+  let s:pending_invocations[self._id] = self
+  if has_key(self._syscall, 'stdin')
+    call system(l:full_cmd, self._syscall.stdin)
+  else
+    call system(l:full_cmd)
+  endif
+  return {}
+endfunction
+
+
+""
+" @private
+" @dict SyscallClientServerInvocation
+function! maktaba#syscall#clientserver#Finish(exit_code) abort dict
+  let l:result_dict = {
+      \ 'status': a:exit_code}
+  let l:result_dict.stdout = join(readfile(self._outfile), "\n")
+  call delete(self._outfile)
+  if filereadable(self._errfile)
+    let l:result_dict.stderr = join(readfile(self._errfile), "\n")
+    call delete(self._errfile)
+  endif
+  call self._invocation.Finish(l:result_dict)
+endfunction

--- a/autoload/maktaba/syscall/invocation.vim
+++ b/autoload/maktaba/syscall/invocation.vim
@@ -1,13 +1,3 @@
-if !exists('s:num_invocations')
-  let s:num_invocations = 0
-endif
-
-""
-" Gets a number uniquely identifying a SyscallInvocation.
-function! s:CreateInvocationId()
-  let s:num_invocations += 1
-  return s:num_invocations
-endfunction
 
 " Compiles a dictionary describing the current vim state.
 function! s:CurrentEnv()
@@ -27,6 +17,7 @@ endfunction
 " status, etc.
 "
 " Public variables:
+" * syscall: The @dict(Syscall) that triggered this invocation.
 " * finished: 0 if the invocation is pending, 1 if finished. The result
 "   variables (status, stdout, stderr) will not exist if the invocation is not
 "   finished.
@@ -43,9 +34,9 @@ endfunction
 " @private
 " Creates a @dict(SyscallInvocation).
 " Private helper only for use by Syscall.CallAsync.
-function! maktaba#syscall#invocation#Create(Callback) abort
+function! maktaba#syscall#invocation#Create(syscall, Callback) abort
   return {
-      \ 'id': s:CreateInvocationId(),
+      \ 'syscall': a:syscall,
       \ 'finished': 0,
       \ '_env': s:CurrentEnv(),
       \ '_callback': a:Callback,
@@ -57,6 +48,7 @@ endfunction
 
 ""
 " @private
+" @dict SyscallInvocation
 " Executes the invocation's callback. The callback must be of prototype:
 " callback(result_dict) or legacy prototype callback(env_dict, result_dict).
 " The latter will be deprecated and stop working in future versions of maktaba.

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -504,14 +504,19 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   where env_dict contains tab, buffer, path, column and line info. This
   fallback will be deprecated and stop working in future versions of maktaba.
 
-  Asynchronous calls are executed via |--remote-expr| using vim's
+  Asynchronous calls are executed via vim's |job| support. If the vim instance
+  is missing job support, this will try to fall back to legacy |clientserver|
+  invocation, which has a few preconditions of its own (see below). If neither
+  option is available, asynchronous calls are not possible, and the call will
+  either throw |ERROR(MissingFeature)| or fall back to synchronous calls,
+  depending on the {allow_sync_fallback} parameter.
+
+  The legacy fallback executes calls via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being
   compiled with +clientserver and |v:servername| being set. Vim will try to
   set it to something when it starts if it is running in X context, e.g.
   'GVIM1'. Otherwise, the user needs to set it by passing |--servername| $NAME
-  to vim. If the two conditions are not met, asynchronous calls are not
-  possible, and the call will either throw |ERROR(MissingFeature)| or fall
-  back to synchronous calls, depending on the {allow_sync_fallback} parameter.
+  to vim.
   Throws ERROR(WrongType)
   Throws ERROR(MissingFeature) if neither async execution nor fallback is
   available.
@@ -541,6 +546,7 @@ Provides a mechanism for interacting with a syscall invocation, checking
 status, etc.
 
 Public variables:
+  * syscall: The |maktaba.Syscall| that triggered this invocation.
   * finished: 0 if the invocation is pending, 1 if finished. The result
     variables (status, stdout, stderr) will not exist if the invocation is not
     finished. Guaranteed to be 1 when an invocation's callback is called.
@@ -1660,6 +1666,16 @@ maktaba#syscall#Create({cmd})                       *maktaba#syscall#Create()*
   automatically escaped and joined. Also accepts an existing Syscall object
   and returns it for convenience.
   Throws ERROR(WrongType)
+
+maktaba#syscall#SetAsyncDisabledForTesting({disabled})
+                                *maktaba#syscall#SetAsyncDisabledForTesting()*
+  Disables asynchronous calls if {disabled} is true. Enables otherwise.
+
+maktaba#syscall#ForceSyncFallbackAllowedForTesting({force})
+                        *maktaba#syscall#ForceSyncFallbackAllowedForTesting()*
+  Sets whether to override |Syscall.CallAsync()|'s allow_sync_fallback
+  argument and unconditionally {force} it to 1. Passing 0 restores normal
+  behavior.
 
 maktaba#test#Override({target}, {replacement})       *maktaba#test#Override()*
   Overrides the function {target} such that when it is called, {replacement}

--- a/vroom/system-vimjob.vroom
+++ b/vroom/system-vimjob.vroom
@@ -1,0 +1,61 @@
+In addition to the functionality featured in system.vroom, the maktaba#syscall#
+helpers feature asynchronous execution powered by vim's native jobs feature.
+
+Before we dive in, let's get maktaba installed and set up the shell override:
+
+  @system (STRICT)
+
+  :set nocompatible
+  :let g:maktabadir = fnamemodify($VROOMFILE, ':p:h:h')
+  :let g:bootstrapfile = g:maktabadir . '/bootstrap.vim'
+  :execute 'source' g:bootstrapfile
+  :call maktaba#system#SetUsableShellRegex('\v<shell\.vroomfaker$')
+
+The examples featured in this file only work with vim instances that support
+vim jobs.
+
+  :if !has('job')<CR>
+  |  echomsg maktaba#error#MissingFeature(
+  |      'Must have +job support to run system-vimjob.vroom examples')<CR>
+  |endif
+
+
+To execute system calls asynchronously, use CallAsync.
+
+  :function AsyncWait(invocation, delay) abort<CR>
+  |  let l:deadline = localtime() + a:delay " wait for at most N seconds<CR>
+  |  while !a:invocation.finished && localtime() < l:deadline<CR>
+  |    sleep 100m<CR>
+  |  endwhile<CR>
+  |  call maktaba#ensure#IsTrue(a:invocation.finished,
+  | 'Async callback was expected to complete within %d seconds', a:delay)<CR>
+  |  return a:invocation<CR>
+  |endfunction
+  :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
+  :function Callback(result) abort<CR>
+  |  let g:callback_stdout = a:result.stdout<CR>
+  |endfunction
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :echomsg g:callback_stdout
+  ~ hi
+  :echomsg g:invocation.stdout
+  ~ hi
+
+Note vroom did NOT expect or hijack the system call above, but it's possible to
+instrument the system calls in vroom where needed by forcing synchronous
+execution.
+
+  :call maktaba#syscall#SetAsyncDisabledForTesting(1)
+  :call maktaba#syscall#ForceSyncFallbackAllowedForTesting(1)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  ! echo hi.*
+
+  :call maktaba#syscall#SetAsyncDisabledForTesting(0)
+  :call maktaba#syscall#ForceSyncFallbackAllowedForTesting(0)
+
+Asynchronous calls can also take a stdin parameter.
+
+  :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :echomsg g:invocation.stdout
+  ~ Hello

--- a/vroom/system.vroom
+++ b/vroom/system.vroom
@@ -372,6 +372,7 @@ To execute system calls asynchronously, use CallAsync.
   :function AsyncWait(invocation, delay) abort<CR>
   |  let l:deadline = localtime() + a:delay " wait for at most N seconds<CR>
   |  while !a:invocation.finished && localtime() < l:deadline<CR>
+  |    sleep 100m<CR>
   |  endwhile<CR>
   |  call maktaba#ensure#IsTrue(a:invocation.finished,
   | 'Async callback was expected to complete within %d seconds', a:delay)<CR>
@@ -381,8 +382,10 @@ To execute system calls asynchronously, use CallAsync.
   :function Callback(result) abort<CR>
   |  let g:callback_stdout = a:result.stdout<CR>
   |endfunction
+  :call maktaba#syscall#SetVimjobDisabledForTesting(1)
   :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
-  ! .*echo hi; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
+  ! .*echo hi; vim --servername .*
+  | --remote-expr "maktaba#syscall#clientserver#FinishInvocation.*
   :echomsg g:callback_stdout
   ~ hi
   :echomsg g:invocation.stdout
@@ -402,13 +405,14 @@ Asynchronous calls can also take a stdin parameter.
 
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
   :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
-  ! .*cat; vim --servername .* --remote-expr "maktaba#syscall#AsyncDone.*
+  ! .*cat; vim --servername .*
+  | --remote-expr "maktaba#syscall#clientserver#FinishInvocation.*
   :echomsg g:invocation.stdout
   ~ Hello
 
 Async calls fall back to synchronous calls if disabled or not available.
 
-  :call maktaba#syscall#SetAsyncDisabled(1)
+  :call maktaba#syscall#SetAsyncDisabledForTesting(1)
   :let g:syscall = maktaba#syscall#Create(['echo', 'hi'])
   :let g:invocation = g:syscall.CallAsync('Callback', 1)
   ! echo hi 2> .*


### PR DESCRIPTION
Enhances Syscall.CallAsync to invoke syscalls as native vim jobs if the vim instance supports them, and demotes the clientserver-based implementation to "legacy" (to be eventually removed in #190).

Resolves #184.