### PR TITLE
Skip python init for JSON when python implementation isn't needed

### DIFF
--- a/autoload/maktaba/json.vim
+++ b/autoload/maktaba/json.vim
@@ -49,8 +49,8 @@ del sys.path[:1]
 EOF
 endfunction
 
-" Try to initialize Vim's Python environment. If that fails, we'll use the
-" Vimscript implementations instead.
+" Try to initialize Vim's Python environment if native JSON support isn't
+" available. If that fails, we'll use the Vimscript implementations instead.
 " maktaba#json#python#Disable() can be used to skip trying to use the
 " Python implementation.
 
@@ -58,7 +58,9 @@ endfunction
 "   7.3.569 added bindeval().
 "   7.3.996 added the vim.List and vim.Dictionary types.
 "   7.3.1042 fixes assigning a dict() containing Unicode keys to a Vim value.
-if v:version < 703 || (v:version == 703 && !has('patch1042'))
+if s:HAS_NATIVE_JSON
+  let s:use_python = 0
+elseif v:version < 703 || (v:version == 703 && !has('patch1042'))
       \ || maktaba#json#python#IsDisabled()
       \ || has('nvim') " neovim does not implement bindeval, which maktaba uses.
   let s:use_python = 0  " Not a recent Vim, or explicitly disabled


### PR DESCRIPTION
Fixes #195.

I did some profiling for fun. Couldn't measure a reliable improvement in overall startup time, but I can see from the `--startuptime` output that it's saving ~10ms of overhead loading json.vim. See `self+sourced` and `self` columns below:
```
times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines
…
- 035.453  000.027  000.027: sourcing /home/dbarnett/.vim/plugged/vim-maktaba/autoload/maktaba/json/python.vim
- 044.654  009.319  009.292: sourcing /home/dbarnett/.vim/plugged/vim-maktaba/autoload/maktaba/json.vim
+ 033.384  000.252  000.252: sourcing /home/dbarnett/.vim/plugged/vim-maktaba/autoload/maktaba/json.vim
```