### PR TITLE
Add python3 support for maktaba#python# and maktaba#buffer#Overwrite

### DIFF
--- a/autoload/maktaba.vim
+++ b/autoload/maktaba.vim
@@ -2,7 +2,7 @@
 " @section Introduction, intro
 " @stylized Maktaba
 " @library
-" @order intro version dicts functions exceptions
+" @order intro version dicts functions exceptions python
 " A vimscript library that hides the worst parts of vimscript and helps you
 " provide consistent plugins.
 "

--- a/autoload/maktaba/buffer.vim
+++ b/autoload/maktaba/buffer.vim
@@ -58,15 +58,17 @@ function! maktaba#buffer#Overwrite(startline, endline, lines) abort
 
   " If python is available, use difflib-based python implementation, which can
   " overwrite only modified chunks and leave equal chunks undisturbed.
-  if has('python')
+  if has('python3') || has('python')
     " TODO: This can throw NotFound if the module fails to load, in which case
     " we perhaps want to log a warning and fall back to the Vimscript
     " implementation.
     call maktaba#python#ImportModule(s:plugin, 'maktaba')
-    python maktaba.OverwriteBufferLines(
-        \ int(vim.eval('a:startline')),
-        \ int(vim.eval('a:endline')),
-        \ vim.eval('a:lines'))
+    let l:python_command = has('python3') ? 'python3' : 'python'
+    execute l:python_command
+        \ "maktaba.OverwriteBufferLines(" .
+            \ "int(vim.eval('a:startline')), " .
+            \ "int(vim.eval('a:endline')), " .
+            \ "vim.eval('a:lines'))"
     return
   endif
 

--- a/autoload/maktaba/python.vim
+++ b/autoload/maktaba/python.vim
@@ -1,8 +1,38 @@
+""
+" @section Python, python
+" Maktaba offers some utilities for using Python consistently in plugins and
+" uses Python if available for a few of its own operations to improve
+" behavior/performance.
+"
+" @subsection Compatibility
+" Vim can be compiled without any Python support, with the Python 2 interface
+" only, with the Python 3 interface, or with support for either (with lots of
+" caveats). See |if_pyth.txt| for context.
+"
+" Maktaba maintains compatibility with both Python 2 and Python 3, and can help
+" plugins built on Maktaba to work with both versions, but there are still some
+" unavoidable corner cases to be aware of:
+" * Plugin authors need to use Python syntax and imports compatible with both
+"   versions if they intend to support both versions. Maktaba can't magically
+"   fix those kinds of incompatibilities for you.
+" * For executing Python statements, explicitly detecting the version and
+"   invoking |:python| or |:python3| is still the best way (and see
+"   |script-here| to avoid errors).
+" * Catching errors gets tricky. Python errors tend to surface as multiple lines
+"   of exception with "Traceback" or other output above the actual error, and
+"   the error types can vary (Maktaba does not attempt to catch and canonicalize
+"   errors from the different implementations and fallbacks).
+" * For users who try to use |python-2-and-3|, Maktaba may break the tie and
+"   trigger Python 3 to load, breaking plugins that subsequently try to use
+"   Python 2 (because a single vim instance can't run both).
+
+
+let s:python_command = has('python3') ? 'python3' : 'python'
+
 
 ""
 " Imports python module {name} into vim from {plugin}.
 " Checks for {name} in the plugin's python/ subdirectory for the named module.
-" @throws NotFound if the module or python/ subdirectory wasn't found.
 "
 " For example:
 " >
@@ -12,38 +42,56 @@
 " will print something like
 "
 "   <module 'foo.bar' from 'repopath/foo/python/foo/bar.py'>
+"
+" @throws NotFound if the module or python/ subdirectory wasn't found.
+" @throws MissingFeature if vim instance is missing Python support.
 function! maktaba#python#ImportModule(plugin, name) abort
+  if !has('python3') && !has('python')
+    throw maktaba#error#MissingFeature('Requires either +python3 or +python')
+  endif
   let l:path = maktaba#path#Join([a:plugin.location, 'python'])
-  python <<EOF
-import sys
-import vim
-
-sys.path.insert(0, vim.eval('l:path'))
-EOF
+  execute s:python_command 'import sys, vim'
+  execute s:python_command "sys.path.insert(0, vim.eval('l:path'))"
   try
-    execute 'python' 'import' a:name
-  catch /Vim(python):/
+    execute s:python_command 'import ' . a:name
+  catch /Vim(python3\?):/
     throw maktaba#error#NotFound('Python module %s', a:name)
+  finally
+    execute s:python_command 'del sys.path[:1]'
   endtry
-  python del sys.path[:1]
 endfunction
 
 
 ""
 " Evaluate python {expr} and return the result.
 "
-" Polyfill for vim's |pyeval()| that works on vim versions older than 7.3.569.
-" You can call pyeval() directly if you don't intend to support vim versions
-" older than that.
+" Polyfill for vim's |pyeval()| or |py3eval()| that works on vim versions older
+" than 7.3.569. You can call pyeval() directly if you don't intend to support
+" vim versions older than that.
 "
 " Supports simple types (number, string, list, dict), but not other python-only
 " types like None, True, or False that have no direct vimscript analog. Those
 " will fail on older vim versions, so either take care to avoid them in the
 " return value or just skip the polyfill and use pyeval() directly.
+"
+" WARNING: This will not have access to l: or a: variables from the caller, so
+" use `vim.eval()` with caution inside {expr}. Call pyeval() directly if you
+" need to access those. Inlining simple values into {expr} can also work, but
+" watch out for issues with string quoting, etc.
+"
+" @throws MissingFeature if vim instance is missing Python support.
 function! maktaba#python#Eval(expr) abort
-  if exists('*pyeval')
+  if !has('python3') && !has('python')
+    throw maktaba#error#MissingFeature('Requires either +python3 or +python')
+  endif
+
+  if exists('*py3eval')
+    return py3eval(a:expr)
+  elseif exists('*pyeval')
     return pyeval(a:expr)
   endif
-  python import json, vim
-  python vim.command('return ' + json.dumps(eval(vim.eval('a:expr'))))
+
+  execute s:python_command 'import json, vim'
+  execute s:python_command
+      \ "vim.command('return ' + json.dumps(eval(vim.eval('a:expr'))))"
 endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -8,6 +8,7 @@ CONTENTS                                                    *maktaba-contents*
   3. Dictionaries..............................................|maktaba-dicts|
   4. Functions.............................................|maktaba-functions|
   5. Error Handling.......................................|maktaba-exceptions|
+  6. Python...................................................|maktaba-python|
 
 ==============================================================================
 INTRODUCTION                                                   *maktaba-intro*
@@ -1467,7 +1468,6 @@ maktaba#plugin#HasFlag({flag})                      *maktaba#plugin#HasFlag()*
 maktaba#python#ImportModule({plugin}, {name})  *maktaba#python#ImportModule()*
   Imports python module {name} into vim from {plugin}. Checks for {name} in
   the plugin's python/ subdirectory for the named module.
-  Throws ERROR(NotFound) if the module or python/ subdirectory wasn't found.
 
   For example:
 >
@@ -1478,18 +1478,28 @@ maktaba#python#ImportModule({plugin}, {name})  *maktaba#python#ImportModule()*
 
     <module 'foo.bar' from 'repopath/foo/python/foo/bar.py'>
 
+  Throws ERROR(NotFound) if the module or python/ subdirectory wasn't found.
+  Throws ERROR(MissingFeature) if vim instance is missing Python support.
+
 maktaba#python#Eval({expr})                            *maktaba#python#Eval()*
   Evaluate python {expr} and return the result.
 
-  Polyfill for vim's |pyeval()| that works on vim versions older than 7.3.569.
-  You can call pyeval() directly if you don't intend to support vim versions
-  older than that.
+  Polyfill for vim's |pyeval()| or |py3eval()| that works on vim versions
+  older than 7.3.569. You can call pyeval() directly if you don't intend to
+  support vim versions older than that.
 
   Supports simple types (number, string, list, dict), but not other
   python-only types like None, True, or False that have no direct vimscript
   analog. Those will fail on older vim versions, so either take care to avoid
   them in the return value or just skip the polyfill and use pyeval()
   directly.
+
+  WARNING: This will not have access to l: or a: variables from the caller, so
+  use `vim.eval()` with caution inside {expr}. Call pyeval() directly if you
+  need to access those. Inlining simple values into {expr} can also work, but
+  watch out for issues with string quoting, etc.
+
+  Throws ERROR(MissingFeature) if vim instance is missing Python support.
 
 maktaba#rtp#Split([paths])                               *maktaba#rtp#Split()*
   Split [paths], a string of comma-separated path entries, into a list of
@@ -1897,6 +1907,35 @@ For use when a |has()| check fails.
 
                                                               *ERROR(Failure)*
 For use in code that should never be reached.
+
+==============================================================================
+PYTHON                                                        *maktaba-python*
+
+Maktaba offers some utilities for using Python consistently in plugins and
+uses Python if available for a few of its own operations to improve
+behavior/performance.
+
+COMPATIBILITY
+Vim can be compiled without any Python support, with the Python 2 interface
+only, with the Python 3 interface, or with support for either (with lots of
+caveats). See |if_pyth.txt| for context.
+
+Maktaba maintains compatibility with both Python 2 and Python 3, and can help
+plugins built on Maktaba to work with both versions, but there are still some
+unavoidable corner cases to be aware of:
+  * Plugin authors need to use Python syntax and imports compatible with both
+    versions if they intend to support both versions. Maktaba can't magically
+    fix those kinds of incompatibilities for you.
+  * For executing Python statements, explicitly detecting the version and
+    invoking |:python| or |:python3| is still the best way (and see
+    |script-here| to avoid errors).
+  * Catching errors gets tricky. Python errors tend to surface as multiple
+    lines of exception with "Traceback" or other output above the actual
+    error, and the error types can vary (Maktaba does not attempt to catch and
+    canonicalize errors from the different implementations and fallbacks).
+  * For users who try to use |python-2-and-3|, Maktaba may break the tie and
+    trigger Python 3 to load, breaking plugins that subsequently try to use
+    Python 2 (because a single vim instance can't run both).
 
 
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Also adds a Python section to Maktaba's help to detail some of the compatibility considerations and a warning on `maktaba#python#Eval` about a gotcha with accessing local variable scopes.

Fixes #193.