### PR TITLE
Preserve trailing slash in maktaba#path#Split

### DIFF
--- a/autoload/maktaba/path.vim
+++ b/autoload/maktaba/path.vim
@@ -171,7 +171,7 @@ endfunction
 " <
 " will echo
 " - `['relative', 'path']`
-" - `['/absolute/path']`
+" - `['/absolute', 'path']`
 " - `['path', 'to', 'dir/']`
 function! maktaba#path#Split(path) abort
   " /foo/bar/baz/ splits to root '/' and components ['foo', 'bar', 'baz/'].

--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -98,7 +98,8 @@ function! s:PluginNameFromDir(dir) abort
   if len(l:splitpath) == 0
     throw maktaba#error#BadValue('Found empty path.')
   endif
-  let l:name = maktaba#plugin#CanonicalName(l:splitpath[-1])
+  let l:name = maktaba#plugin#CanonicalName(
+      \ maktaba#path#StripTrailingSlash(l:splitpath[-1]))
   return l:name
 endfunction
 
@@ -540,7 +541,8 @@ function! s:GetSubdirs() dict abort
     " Glob includes trailing slash, which makes glob() only detect directories.
     let l:direct_glob = maktaba#path#Join([self.location, '*', ''])
     let l:direct_dirs = split(glob(l:direct_glob, 1), "\n")
-    let self._dirs = map(l:direct_dirs, 'maktaba#path#Split(v:val)[-1]')
+    let self._dirs = map(
+        \ l:direct_dirs, 'maktaba#path#AsDir(maktaba#path#Split(v:val)[-1])')
   endif
   return self._dirs
 endfunction
@@ -555,7 +557,8 @@ function! s:GetAfterSubdirs() dict abort
     " Glob includes trailing slash, which makes glob() only detect directories.
     let l:after_glob = maktaba#path#Join([self.location, 'after', '*', ''])
     let l:after_dirs = split(glob(l:after_glob, 1), "\n")
-    let self._after_dirs = map(l:after_dirs, 'maktaba#path#Split(v:val)[-1]')
+    let self._after_dirs = map(
+        \ l:after_dirs, 'maktaba#path#AsDir(maktaba#path#Split(v:val)[-1])')
   endif
   return self._after_dirs
 endfunction
@@ -705,7 +708,8 @@ endfunction
 function! maktaba#plugin#HasDir(dir) dict abort
   let l:dirs = call('s:GetSubdirs', [], self)
   let l:after_dirs = call('s:GetAfterSubdirs', [], self)
-  return index(l:dirs, a:dir) > -1 || index(l:after_dirs, a:dir) > -1
+  return index(l:dirs, maktaba#path#AsDir(a:dir)) > -1 ||
+      \ index(l:after_dirs, maktaba#path#AsDir(a:dir)) > -1
 endfunction
 
 

--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -30,7 +30,8 @@ function! s:GetLeafDir(path) abort
   if l:leaf isnot 0
     return l:leaf
   endif
-  let s:cache_leafdirs[a:path] = maktaba#path#Split(a:path)[-1]
+  let s:cache_leafdirs[a:path] =
+      \ maktaba#path#StripTrailingSlash(maktaba#path#Split(a:path)[-1])
   return s:cache_leafdirs[a:path]
 endfunction
 

--- a/autoload/maktaba/rtp.vim
+++ b/autoload/maktaba/rtp.vim
@@ -37,16 +37,6 @@ endfunction
 
 
 ""
-" Returns {path} with trailing slashes safely removed.
-" Used by @function(#Join) since 'runtimepath' typically stores paths without
-" trailing slashes.
-function! s:StripTrailingSlash(path) abort
-  " Uses maktaba#path#AsDir to ensure a single trailing slash, then removes it.
-  return maktaba#path#AsDir(a:path)[:-2]
-endfunction
-
-
-""
 " Split [paths], a string of comma-separated path entries, into a list of paths.
 " Handles unescaping the commas.
 " Paths will be canonicalized using @function(#AsDir) so they're unambiguously
@@ -75,8 +65,9 @@ endfunction
 " representation, with trailing slashes included.
 function! maktaba#rtp#Join(paths) abort
   call maktaba#ensure#IsList(a:paths)
-  return join(
-      \ map(copy(a:paths), "escape(s:StripTrailingSlash(v:val), '\,')"), ',')
+  return join(map(
+      \ copy(a:paths),
+      \ "escape(maktaba#path#StripTrailingSlash(v:val), '\,')"), ',')
 endfunction
 
 

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1266,7 +1266,17 @@ maktaba#path#Join({components})                          *maktaba#path#Join()*
   is '/absolute'
 
 maktaba#path#Split({path})                              *maktaba#path#Split()*
-  Splits {path} on the system separator character.
+  Splits {path} on the system separator character, preserving root and
+  trailing slash, if any. For example:
+>
+    :echomsg maktaba#path#Split('relative/path')
+    :echomsg maktaba#path#Split('/absolute/path')
+    :echomsg maktaba#path#Split('path/to/dir/')
+<
+  will echo
+  `['relative', 'path']`
+  `['/absolute/path']`
+  `['path', 'to', 'dir/']`
 
 maktaba#path#Basename({path})                        *maktaba#path#Basename()*
   The basename of {path}. Trailing slash matters. Consider:

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1245,6 +1245,10 @@ maktaba#path#AsDir({path})                              *maktaba#path#AsDir()*
   directory paths, so utilities like |maktaba#path#Dirname()| don't try to
   interpret them as file paths.
 
+maktaba#path#StripTrailingSlash({path})    *maktaba#path#StripTrailingSlash()*
+  Returns {path} with trailing slashes (if any) stripped (forward or
+  backslash, depending on platform).
+
 maktaba#path#RootComponent({path})              *maktaba#path#RootComponent()*
   Returns the root component of {path}. In unix, / is the only root. In
   windows, the root can be \ (which vim treats as the default drive), a drive

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1279,7 +1279,7 @@ maktaba#path#Split({path})                              *maktaba#path#Split()*
 <
   will echo
   `['relative', 'path']`
-  `['/absolute/path']`
+  `['/absolute', 'path']`
   `['path', 'to', 'dir/']`
 
 maktaba#path#Basename({path})                        *maktaba#path#Basename()*

--- a/vroom/path.vroom
+++ b/vroom/path.vroom
@@ -155,8 +155,12 @@ makes one absolute path relative to another.
   |    '/deep/in/the/heart/of/texas')
   ~ ../../../../heart/of/texas
 
-  :echomsg maktaba#path#MakeRelative('/point/A/', '/point/A/')
+  :echomsg maktaba#path#MakeRelative('/point/A', '/point/A')
   ~ .
+  :echomsg maktaba#path#MakeRelative('/point/A/', '/point/A/')
+  ~ ./
+  :echomsg maktaba#path#MakeRelative('/point/A', '/point/A/')
+  ~ ./
 
 Your paths had better be absolute before trying this.
 

--- a/vroom/path.vroom
+++ b/vroom/path.vroom
@@ -30,10 +30,10 @@ helps you recognize relative paths.
   :echomsg string(maktaba#path#Split('relative/path'))
   ~ ['relative', 'path']
 
-Trailing slashes make no difference, though:
+Trailing slashes are preserved as well:
 
   :echomsg string(maktaba#path#Split('relative/path/'))
-  ~ ['relative', 'path']
+  ~ ['relative', 'path/']
 
 
 

--- a/vroom/plugin.vroom
+++ b/vroom/plugin.vroom
@@ -166,7 +166,8 @@ and location:
 
   :echomsg g:plugin.name
   ~ myplugin
-  :echomsg maktaba#path#Split(g:plugin.location)[-1]
+  :echomsg maktaba#path#StripTrailingSlash(
+  |maktaba#path#Split(g:plugin.location)[-1])
   ~ myplugin
 
 These, too, are somewhat boring (except for the fact that you should NEVER EVER


### PR DESCRIPTION
Also improves `maktaba#path#MakeRelative` to preserve trailing slash and adds a `maktaba#path#StripTrailingSlash()`.

A little profiling since I was concerned about hotspot performance regressions…
Profile summary before this change:
```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  874   0.070503   0.042762  maktaba#path#Join()
 3296              0.042045  maktaba#path#AsDir()
   42   0.040494   0.025003  maktaba#rtp#LeafDirs()
  658   0.021195   0.014652  maktaba#setting#ParseHandle()
   41   0.054411   0.012718  maktaba#rtp#Join()
  559   0.018049   0.012574  maktaba#value#Focus()
  610   0.056664   0.012383  maktaba#plugin#Flag()
 3144              0.011213  maktaba#ensure#TypeMatches()
 2517              0.009126  maktaba#path#RootComponent()
  132   0.124043   0.007136  maktaba#plugin#GetOrInstall()
 2006   0.013524   0.006436  maktaba#ensure#IsList()
  147   0.009870   0.005441  maktaba#string#Strip()
  148   0.072684   0.005021  maktaba#function#Call()
   92   0.057603   0.004935  maktaba#plugin#Enter()
  171   0.005266   0.004645  maktaba#path#Split()
  610   0.023335   0.004571  maktaba#setting#Handle()
  175   0.005383   0.004011  maktaba#flags#Create()
  159   0.004876   0.003906  maktaba#rtp#Split()
   77   0.017688   0.003549  maktaba#plugin#AddonInfo()
   80   0.067771   0.003027  maktaba#plugin#Source()
```
Profile summary after this change:
```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  874   0.070339   0.042532  maktaba#path#Join()
 2867              0.030666  maktaba#path#StripTrailingSlash()
   42   0.043343   0.026018  maktaba#rtp#LeafDirs()
  658   0.021416   0.014772  maktaba#setting#ParseHandle()
  610   0.057293   0.012579  maktaba#plugin#Flag()
  559   0.018096   0.012517  maktaba#value#Focus()
 3144              0.011521  maktaba#ensure#TypeMatches()
   41   0.041070   0.011328  maktaba#rtp#Join()
  808              0.010794  maktaba#path#AsDir()
 2517              0.009276  maktaba#path#RootComponent()
  132   0.125767   0.007175  maktaba#plugin#GetOrInstall()
 2006   0.013761   0.006481  maktaba#ensure#IsList()
  147   0.009712   0.005320  maktaba#string#Strip()
  148   0.080790   0.005243  maktaba#function#Call()
   92   0.058992   0.005129  maktaba#plugin#Enter()
  171   0.005646   0.005018  maktaba#path#Split()
  610   0.023532   0.004599  maktaba#setting#Handle()
  175   0.005448   0.004046  maktaba#flags#Create()
  159   0.004840   0.003883  maktaba#rtp#Split()
   77   0.017444   0.003549  maktaba#plugin#AddonInfo()
```
Actually seems to save a little overhead by replacing the `s:StripTrailingSlash` hack in rtp.vim with a simpler substitution (instead of using `#path#AsDir` and slicing). Certainly not a significant performance regression, at any rate.

Fixes #137 and #175.