### PR TITLE
Implement maktaba#log#GetFormattedEntries and support 1-arg handler

### DIFF
--- a/autoload/maktaba/log.vim
+++ b/autoload/maktaba/log.vim
@@ -94,7 +94,7 @@ function! s:FormatLogEntry(entry) abort
   endtry
   return printf('%s %s [%s] %s',
       \ l:level_name,
-      \ strftime('%Y-%m-%d@%H:%M:%S', l:timestamp),
+      \ strftime('%Y-%m-%dT%H:%M:%S', l:timestamp),
       \ l:context,
       \ l:message)
 endfunction

--- a/autoload/maktaba/log.vim
+++ b/autoload/maktaba/log.vim
@@ -41,6 +41,19 @@ endfunction
 
 
 ""
+" Call {Handler} with {logitem}, trying both 1-arg and legacy 4-arg
+" signatures.
+function! s:CallHandler(Handler, logitem) abort
+  try
+    call maktaba#function#Call(a:Handler, [a:logitem])
+  catch /E119:/
+    " Not enough arguments. Fall back to legacy 4-arg handler signature.
+    call maktaba#function#Call(a:Handler, a:logitem)
+  endtry
+endfunction
+
+
+""
 " Append {logitem} to s:log_queue and pass to handlers.
 function! s:SendToHandlers(logitem) abort
   let l:maktaba = maktaba#Maktaba()
@@ -65,8 +78,25 @@ function! s:SendToHandlers(logitem) abort
 
   " Send to handlers.
   for l:Handler in l:maktaba.globals.loghandlers.Items()
-    call maktaba#function#Call(l:Handler, a:logitem)
+    call s:CallHandler(l:Handler, a:logitem)
   endfor
+endfunction
+
+
+""
+" Gets a string representing a single log {entry}.
+function! s:FormatLogEntry(entry) abort
+  let [l:level, l:timestamp, l:context, l:message] = a:entry
+  try
+    let l:level_name = s:LEVELS.Name(l:level)
+  catch /ERROR(NotFound):/
+    let l:level_name = '?'
+  endtry
+  return printf('%s %s [%s] %s',
+      \ l:level_name,
+      \ strftime('%Y-%m-%d@%H:%M:%S', l:timestamp),
+      \ l:context,
+      \ l:message)
 endfunction
 
 
@@ -131,9 +161,13 @@ endfunction
 
 ""
 " @usage {handler} [fire_recent]
-" Registers {handler} to receive log messages. {handler} must refer to a
-" function that takes 4 arguments: level (number), timestamp (number),
-" context (string), and message (string).
+" Registers {handler} to receive log entries. {handler} must refer to a
+" function that takes 1 argument, an opaque data structure representing a log
+" entry. Handlers can collect these and them pass back as a list into maktaba
+" log entry manipulation functions like @function(#GetFormattedEntries).
+"
+" As a legacy fallback, maktaba will support a handler that takes 4 arguments:
+" level (number), timestamp (number), context (string), and message (string).
 "
 " If [fire_recent] is 1 and messages have already been logged before a handler
 " is added, some recent messages may be passed to the handler as soon as it's
@@ -151,8 +185,28 @@ function! maktaba#log#AddHandler(Handler, ...) abort
   if l:fire_recent
     " Send recent queued messages to handler.
     for l:logitem in s:log_queue
-      call maktaba#function#Call(a:Handler, l:logitem)
+      call s:CallHandler(a:Handler, l:logitem)
     endfor
   endif
   return l:remover
+endfunction
+
+
+""
+" Returns a list of human-readable strings each representing a log entry from
+" {entries}.
+" Excludes messages with level less than {minlevel} or not originating from
+" one of [contexts]. To get the entire unfiltered list of entries, pass a
+" {minlevel} of `maktaba#log#LEVELS.DEBUG` and no [contexts] arg.
+" Each item in {entries} must be a value maktaba passed to a log handler call.
+function! maktaba#log#GetFormattedEntries(entries, minlevel, ...) abort
+  call maktaba#ensure#IsIn(a:minlevel, s:LEVELS.Values())
+  let l:filter = 'v:val[0] >= a:minlevel'
+  if a:0 >= 1
+    let l:contexts = a:1
+    call maktaba#ensure#IsList(l:contexts)
+    let l:filter .= ' && index(l:contexts, v:val[2]) != -1'
+  endif
+  let l:filtered_entries = filter(copy(a:entries), l:filter)
+  return map(l:filtered_entries, 's:FormatLogEntry(v:val)')
 endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -1230,9 +1230,13 @@ maktaba#log#Logger({context})                           *maktaba#log#Logger()*
   Creates a |maktaba.Logger| interface for {context}.
 
 maktaba#log#AddHandler({handler}, [fire_recent])    *maktaba#log#AddHandler()*
-  Registers {handler} to receive log messages. {handler} must refer to a
-  function that takes 4 arguments: level (number), timestamp (number), context
-  (string), and message (string).
+  Registers {handler} to receive log entries. {handler} must refer to a
+  function that takes 1 argument, an opaque data structure representing a log
+  entry. Handlers can collect these and them pass back as a list into maktaba
+  log entry manipulation functions like |maktaba#log#GetFormattedEntries()|.
+
+  As a legacy fallback, maktaba will support a handler that takes 4 arguments:
+  level (number), timestamp (number), context (string), and message (string).
 
   If [fire_recent] is 1 and messages have already been logged before a handler
   is added, some recent messages may be passed to the handler as soon as it's
@@ -1242,6 +1246,15 @@ maktaba#log#AddHandler({handler}, [fire_recent])    *maktaba#log#AddHandler()*
   This function returns a function which, when applied, unregisters {handler}.
   Hold on to it if you expect you'll need to remove {handler}.
   [fire_recent] is 0 if omitted.
+
+maktaba#log#GetFormattedEntries({entries}, {minlevel}, [contexts])
+                                           *maktaba#log#GetFormattedEntries()*
+  Returns a list of human-readable strings each representing a log entry from
+  {entries}. Excludes messages with level less than {minlevel} or not
+  originating from one of [contexts]. To get the entire unfiltered list of
+  entries, pass a {minlevel} of `maktaba#log#LEVELS.DEBUG` and no [contexts]
+  arg. Each item in {entries} must be a value maktaba passed to a log handler
+  call.
 
 maktaba#path#AsDir({path})                              *maktaba#path#AsDir()*
   Returns {path} with trailing slash (forward or backslash, depending on

--- a/vroom/log.vroom
+++ b/vroom/log.vroom
@@ -57,18 +57,18 @@ awkward to get a logger plugin installed before anything else that needs it,
 maktaba holds on to a few recent messages for you. Here come the messages we
 logged earlier...
 
-  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] why (regex)
-  ~ Log message: INFO [-0-9@:]+ \[VROOMFILE\] hello (regex)
-  ~ Log message: WARN [-0-9@:]+ \[VROOMFILE\] there (regex)
-  ~ Log message: ERROR [-0-9@:]+ \[VROOMFILE\] my (regex)
-  ~ Log message: SEVERE [-0-9@:]+ \[VROOMFILE\] friend (regex)
+  ~ Log message: DEBUG [-0-9T:]+ \[VROOMFILE\] why (regex)
+  ~ Log message: INFO [-0-9T:]+ \[VROOMFILE\] hello (regex)
+  ~ Log message: WARN [-0-9T:]+ \[VROOMFILE\] there (regex)
+  ~ Log message: ERROR [-0-9T:]+ \[VROOMFILE\] my (regex)
+  ~ Log message: SEVERE [-0-9T:]+ \[VROOMFILE\] friend (regex)
 
-  ~ Log message: DEBUG [-0-9@:]+ \[emptyplugin\] Hello from emptyplugin (regex)
+  ~ Log message: DEBUG [-0-9T:]+ \[emptyplugin\] Hello from emptyplugin (regex)
 
 New messages are logged as they arrive.
 
   :call g:vroom_logger.Debug('This just in.')
-  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] This just in\. (regex)
+  ~ Log message: DEBUG [-0-9T:]+ \[VROOMFILE\] This just in\. (regex)
 
 You may have noticed the return value from maktaba#log#AddHandler being saved as
 g:rm_echohandler above. AddHandler returns a remover function you can use to
@@ -85,7 +85,7 @@ lets you control that.
 
   :let g:rm_echohandler = maktaba#log#AddHandler('LogHandler', 0)
   :call g:vroom_logger.Info('I am now totally awake.')
-  ~ Log message: INFO [-0-9@:]+ \[VROOMFILE\] I am now totally awake\. (regex)
+  ~ Log message: INFO [-0-9T:]+ \[VROOMFILE\] I am now totally awake\. (regex)
 
   :call maktaba#function#Call(g:rm_echohandler)
 
@@ -100,7 +100,7 @@ fallback for now.
   |endfunction
   :let g:rm_echohandler = maktaba#log#AddHandler('LegacyLogHandler', 0)
   :call g:vroom_logger.Info('Testing.')
-  ~ Log message \(legacy\): INFO [-0-9@:]+ \[VROOMFILE\] Testing\. (regex)
+  ~ Log message \(legacy\): INFO [-0-9T:]+ \[VROOMFILE\] Testing\. (regex)
 
   :call maktaba#function#Call(g:rm_echohandler)
 
@@ -126,10 +126,10 @@ isn't there).
   :  let g:i += 1
   :endwhile
   :call maktaba#log#AddHandler('FirstFewHandler', 1)
-  ~ Log message: INFO [-0-9@:]+ \[maktaba\] [0-9]+ messages not (regex)
+  ~ Log message: INFO [-0-9T:]+ \[maktaba\] [0-9]+ messages not (regex)
   | available because logging was configured late.
-  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] Message 2 (regex)
-  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] Message 3 (regex)
+  ~ Log message: DEBUG [-0-9T:]+ \[VROOMFILE\] Message 2 (regex)
+  ~ Log message: DEBUG [-0-9T:]+ \[VROOMFILE\] Message 3 (regex)
 
 This limit is not configurable, but it should give you more than enough headroom
 to get a real log collection plugin installed and running without losing

--- a/vroom/log.vroom
+++ b/vroom/log.vroom
@@ -44,10 +44,12 @@ callback-based API for log viewing plugins to subscribe to log messages as they
 arrive.
 
   :let g:LEVELS = maktaba#log#LEVELS
-  :function LogHandler(level, timestamp, context, message) abort
-  :  echomsg printf('Log message: %s %s [%s] %s', g:LEVELS.Name(a:level),
-  | string(a:timestamp), a:context, a:message)
-  :endfunction
+  :function FormatSingleEntry(entry) abort<CR>
+  |  return maktaba#log#GetFormattedEntries([a:entry], g:LEVELS.DEBUG)[0]<CR>
+  |endfunction
+  :function LogHandler(entry) abort<CR>
+  |  echomsg 'Log message: ' . FormatSingleEntry(a:entry)<CR>
+  |endfunction
   :let g:rm_echohandler = maktaba#log#AddHandler('LogHandler', 1)
 
 Since a few log messages can come very early in initialization, and it may be
@@ -55,18 +57,18 @@ awkward to get a logger plugin installed before anything else that needs it,
 maktaba holds on to a few recent messages for you. Here come the messages we
 logged earlier...
 
-  ~ Log message: DEBUG [0-9]+ \[VROOMFILE\] why (regex)
-  ~ Log message: INFO [0-9]+ \[VROOMFILE\] hello (regex)
-  ~ Log message: WARN [0-9]+ \[VROOMFILE\] there (regex)
-  ~ Log message: ERROR [0-9]+ \[VROOMFILE\] my (regex)
-  ~ Log message: SEVERE [0-9]+ \[VROOMFILE\] friend (regex)
+  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] why (regex)
+  ~ Log message: INFO [-0-9@:]+ \[VROOMFILE\] hello (regex)
+  ~ Log message: WARN [-0-9@:]+ \[VROOMFILE\] there (regex)
+  ~ Log message: ERROR [-0-9@:]+ \[VROOMFILE\] my (regex)
+  ~ Log message: SEVERE [-0-9@:]+ \[VROOMFILE\] friend (regex)
 
-  ~ Log message: DEBUG [0-9]+ \[emptyplugin\] Hello from emptyplugin (regex)
+  ~ Log message: DEBUG [-0-9@:]+ \[emptyplugin\] Hello from emptyplugin (regex)
 
 New messages are logged as they arrive.
 
   :call g:vroom_logger.Debug('This just in.')
-  ~ Log message: DEBUG [0-9]+ \[VROOMFILE\] This just in. (regex)
+  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] This just in\. (regex)
 
 You may have noticed the return value from maktaba#log#AddHandler being saved as
 g:rm_echohandler above. AddHandler returns a remover function you can use to
@@ -77,21 +79,46 @@ un-register the handler again.
   :call g:vroom_logger.Debug('Hey! Who turned out the lights?')
   @messages
 
+If you want to register a handler that doesn't receive recent messages (just new
+messages logged after it's registered), the fire_recent argument to AddHandler
+lets you control that.
+
+  :let g:rm_echohandler = maktaba#log#AddHandler('LogHandler', 0)
+  :call g:vroom_logger.Info('I am now totally awake.')
+  ~ Log message: INFO [-0-9@:]+ \[VROOMFILE\] I am now totally awake\. (regex)
+
+  :call maktaba#function#Call(g:rm_echohandler)
+
+The log handler function should take a single argument, an opaque data structure
+representing a log entry. Older versions of maktaba expected a handler function
+that takes 4 arguments, and that signature is still supported as a legacy
+fallback for now.
+
+  :function LegacyLogHandler(level, timestamp, context, message) abort<CR>
+  |  echomsg 'Log message (legacy): ' . FormatSingleEntry(
+  |[a:level, a:timestamp, a:context, a:message])<CR>
+  |endfunction
+  :let g:rm_echohandler = maktaba#log#AddHandler('LegacyLogHandler', 0)
+  :call g:vroom_logger.Info('Testing.')
+  ~ Log message \(legacy\): INFO [-0-9@:]+ \[VROOMFILE\] Testing\. (regex)
+
+  :call maktaba#function#Call(g:rm_echohandler)
+
 
 As mentioned above, maktaba holds on to a few recent messages for convenience.
-But that's not made to be long-term storage. maktaba holds up to 100 recent
-messages. Beyond that, it truncates with a message to let you know it truncated
-(so it doesn't silently drop history and leave you wondering why a particular
-message isn't there).
+But that's not made to be long-term storage. maktaba holds a few recent
+messages (controlled by vim's 'history' setting, which usually defaults to 50).
+Beyond that, it truncates with a message to let you know it truncated (so it
+doesn't silently drop history and leave you wondering why a particular message
+isn't there).
 
   :let g:n_messages_seen = 0
-  :function FirstFewHandler(level, timestamp, context, message) abort
-  :  if g:n_messages_seen < 3
-  :    echomsg printf('Log message: %s %s [%s] %s', g:LEVELS.Name(a:level),
-  | string(a:timestamp), a:context, a:message)
-  :  endif
-  :  let g:n_messages_seen += 1
-  :endfunction
+  :function FirstFewHandler(entry) abort<CR>
+  |  if g:n_messages_seen < 3<CR>
+  |    echomsg 'Log message: ' . FormatSingleEntry(a:entry)<CR>
+  |  endif<CR>
+  |  let g:n_messages_seen += 1<CR>
+  |endfunction
 
   :let g:i = 0
   :while g:i < &history + 1
@@ -99,10 +126,10 @@ message isn't there).
   :  let g:i += 1
   :endwhile
   :call maktaba#log#AddHandler('FirstFewHandler', 1)
-  ~ Log message: INFO [0-9]+ \[maktaba\] [0-9]+ messages not available (regex)
-  | because logging was configured late.
-  ~ Log message: DEBUG [0-9]+ \[VROOMFILE\] Message 2 (regex)
-  ~ Log message: DEBUG [0-9]+ \[VROOMFILE\] Message 3 (regex)
+  ~ Log message: INFO [-0-9@:]+ \[maktaba\] [0-9]+ messages not (regex)
+  | available because logging was configured late.
+  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] Message 2 (regex)
+  ~ Log message: DEBUG [-0-9@:]+ \[VROOMFILE\] Message 3 (regex)
 
 This limit is not configurable, but it should give you more than enough headroom
 to get a real log collection plugin installed and running without losing


### PR DESCRIPTION
These changes help log handlers treat log entries as opaque data structures so maktaba can evolve the format as needed w/o having to coordinate versioning with callers. Entry format will be changed slightly in #103 after callers have a chance to migrate to this helper.

Note the "Not enough arguments" fallback could conceivably cause performance regressions until the callers are updated if there's a ton of logging, but I tried it out on a fairly heavy vim configuration with a lot of plugins and logging and I couldn't measure a reliable performance regression comparing `time vim -c quit` output with and without.