### PR TITLE
Use shell for CallAsync with vim jobs

### DIFF
--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -396,7 +396,7 @@ endfunction
 
 ""
 " @private
-" Sets the regex that @function(Syscall.Call) and
+" Sets the regex that @function(Syscall.Call), @function(Syscall.CallAsync), and
 " @function(Syscall.CallForeground) use to decide whether 'shell' is usable. If
 " 'shell' is unusable, they will use /bin/sh instead. You should NOT use this
 " function to make vim use your preferred shell (ESPECIALLY if your shell is
@@ -408,6 +408,15 @@ endfunction
 function! maktaba#syscall#SetUsableShellRegex(regex) abort
   call maktaba#ensure#IsString(a:regex)
   let s:usable_shell = a:regex
+endfunction
+
+
+""
+" @private
+" Gets the regex that @function(Syscall.Call), @function(Syscall.CallAsync), and
+" @function(Syscall.CallForeground) use to decide whether 'shell' is usable.
+function! maktaba#syscall#GetUsableShellRegex() abort
+  return s:usable_shell
 endfunction
 
 

--- a/autoload/maktaba/syscall/async.vim
+++ b/autoload/maktaba/syscall/async.vim
@@ -23,8 +23,13 @@ endfunction
 " to it.
 " The vim job implementation for @function(#CallAsync).
 function! maktaba#syscall#async#Start() abort dict
-  " NOTE: Doesn't need to override &shell since it's not used by job_start().
-  let self._job = job_start(self._syscall.GetCommand(), {
+  " Unlike system, job_start doesn't automatically create a shell
+  if &shell =~# maktaba#syscall#GetUsableShellRegex()
+    let shell_command = [&shell, &shellcmdflag, self._syscall.GetCommand()]
+  else
+    let shell_command = ['sh', '-c', self._syscall.GetCommand()]
+  endif
+  let self._job = job_start(shell_command, {
       \ 'out_mode': 'raw',
       \ 'err_mode': 'raw',
       \ 'out_cb': self.HandleStdout,

--- a/vroom/system-vimjob.vroom
+++ b/vroom/system-vimjob.vroom
@@ -36,14 +36,13 @@ To execute system calls asynchronously, use CallAsync.
   |  let g:callback_stdout = a:result.stdout<CR>
   |endfunction
   :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  ! echo hi
   :echomsg g:callback_stdout
   ~ hi
   :echomsg g:invocation.stdout
   ~ hi
 
-Note vroom did NOT expect or hijack the system call above, but it's possible to
-instrument the system calls in vroom where needed by forcing synchronous
-execution.
+It is also possible to force synchronous execution.
 
   :call maktaba#syscall#SetAsyncDisabledForTesting(1)
   :call maktaba#syscall#ForceSyncFallbackAllowedForTesting(1)
@@ -57,5 +56,20 @@ Asynchronous calls can also take a stdin parameter.
 
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
   :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  ! cat
   :echomsg g:invocation.stdout
   ~ Hello
+
+And() and Or() can also be used to chain Asynchronous commands.
+
+  :let g:syscall = maktaba#syscall#Create('true').And('echo SUCCESS')
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  ! true && echo SUCCESS
+  :echomsg g:invocation.stdout
+  ~ SUCCESS
+
+  :let g:syscall = maktaba#syscall#Create('false').And('echo FAILURE')
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  ! false && echo FAILURE
+  :echomsg g:invocation.stdout
+  ~ FAILURE


### PR DESCRIPTION
syscall functions assume shell-like behavior, but job_start doesn't use
a shell.

Fixes #205