### PR TITLE
Update .travis.yml to use vroom 0.13.0 (w/ neovim fix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
     elif [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
       wget https://bootstrap.pypa.io/get-pip.py &&
-      sudo python3 get-pip.py --allow-external sudo &&
+      sudo python3 get-pip.py &&
       sudo pip3 install neovim;
     fi
-  - wget https://github.com/google/vroom/releases/download/v0.12.0/vroom_0.12.0-1_all.deb
-  - sudo dpkg -i ./vroom_0.12.0-1_all.deb
+  - wget https://github.com/google/vroom/releases/download/v0.13.0/vroom_0.13.0-1_all.deb
+  - sudo dpkg -i ./vroom_0.13.0-1_all.deb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
   - vroom $VROOM_ARGS --crawl --skip=vroom/system-vimjob.vroom


### PR DESCRIPTION
Updates to use vroom 0.13.0 which fixes support for newer versions of neovim python client (0.1.6 and newer). Also removes a `--allow-external` option which the pip script seems to no longer support and apparently no longer needs.

Note that most vroom tests still hang in neovim mode (see google/vroom#83 and google/vroom#100), so we are not ready to remove the `allow_failures` override for neovim tests.