### PR TITLE
Fix documentation for Plugin.IsLibrary()

### DIFF
--- a/autoload/maktaba/plugin.vim
+++ b/autoload/maktaba/plugin.vim
@@ -875,8 +875,7 @@ endfunction
 " Checks that this plugin is a library plugin.
 " In order to be a library plugin, the plugin must contain an autoload/
 " directory and must not contain ftplugin/, ftdetect/, syntax/, indent/,
-" nor instant/ directories. If it contains a plugin/ directory, that directory
-" must contain only a flags.vim file.
+" plugin/, nor instant/ directories.
 function! maktaba#plugin#IsLibrary() dict abort
   for l:special in maktaba#plugin#NonlibraryDirs()
     if self.HasDir(l:special)

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -359,9 +359,7 @@ Plugin.MapPrefix({letter}, [throw])                       *Plugin.MapPrefix()*
 Plugin.IsLibrary()                                        *Plugin.IsLibrary()*
   Checks that this plugin is a library plugin. In order to be a library
   plugin, the plugin must contain an autoload/ directory and must not contain
-  ftplugin/, ftdetect/, syntax/, indent/, nor instant/ directories. If it
-  contains a plugin/ directory, that directory must contain only a flags.vim
-  file.
+  ftplugin/, ftdetect/, syntax/, indent/, plugin/, nor instant/ directories.
 
 Plugin.GetExtensionRegistry()                  *Plugin.GetExtensionRegistry()*
   Returns the |maktaba.ExtensionRegistry| belonging to this plugin.


### PR DESCRIPTION
The documentation for this function incorrectly says that a plugin may have a 'plugin/flags.vim' file and still be considered a library plugin. The lines in question were last touched in December 2013, which makes me think that this might've been planned behavior, but then people might've later changed their minds?

If I'm wrong about this, just let me know! It's a minor fix either way, so if the docs were right, then I'd totally be willing to tweak the implementation instead.