### PR TITLE
Change the default key to be a NoOp for Selector

### DIFF
--- a/autoload/maktaba/selector.vim
+++ b/autoload/maktaba/selector.vim
@@ -143,12 +143,6 @@ function! s:BaseSyntax() abort
 endfunction
 
 
-" A default key mapping function -- not very useful.
-function! s:DefaultAfterKey(line, ...) abort
-  execute 'edit ' . a:line
-endfunction
-
-
 ""
 " @dict Selector
 " Representation of a set of data for a user to select from, e.g. list of files.

--- a/autoload/maktaba/selector.vim
+++ b/autoload/maktaba/selector.vim
@@ -23,7 +23,7 @@ endif
 " The default keymappings.
 function! s:GetDefaultKeyMappings() abort
   return {
-      \ '<CR>' : ['s:DefaultAfterKey', 'Close', 'Do something'],
+      \ '<CR>' : ['maktaba#selector#NoOp', 'Close', 'Do something'],
       \ s:HELP_KEY : [
           \ 'maktaba#selector#ToggleCurrentHelp',
           \ 'NoOp',


### PR DESCRIPTION
It's confusing and probably wrong to perform an edit. So, change to a no-op.