### PR TITLE
Fail #python#ImportModule with clearer errors

### DIFF
--- a/autoload/maktaba/python.vim
+++ b/autoload/maktaba/python.vim
@@ -55,7 +55,11 @@ function! maktaba#python#ImportModule(plugin, name) abort
   try
     execute s:python_command 'import ' . a:name
   catch /Vim(python3\?\|return):/  " return is used by Neovim (https://github.com/neovim/neovim/issues/7294).
-    throw maktaba#error#NotFound('Python module %s', a:name)
+    throw maktaba#error#NotFound(
+        \ 'Failed to import python module %s from %s: %s',
+        \ a:name,
+        \ l:path,
+        \ v:exception)
   finally
     execute s:python_command 'del sys.path[:1]'
   endtry


### PR DESCRIPTION
Helps with #231 by surfacing more details about where it tried to import the module from and the actual error thrown in case it's something more interesting than ModuleNotFoundError.