### PR TITLE
Remove deprecated "is not" usage in maktaba.py

### DIFF
--- a/python/maktaba.py
+++ b/python/maktaba.py
@@ -29,5 +29,5 @@ def OverwriteBufferLines(startline, endline, lines):
   sequence = difflib.SequenceMatcher(None, orig_lines, lines)
   offset = startline - 1
   for tag, i1, i2, j1, j2 in reversed(sequence.get_opcodes()):
-    if tag is not 'equal':
+    if tag != 'equal':
       vim.current.buffer[i1+offset:i2+offset] = lines[j1:j2]


### PR DESCRIPTION
Using "is" or "is not" operators with a string literal now produces a SyntaxWarning in python 3.8 (https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior), and the warning seems to cause some versions of neovim to blow up in cases like #231.