### PR TITLE
Add native job support for neovim.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ services:
   - xvfb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
-  - vroom $VROOM_ARGS --crawl
+  - vroom $VROOM_ARGS --crawl --skip=vroom/system-job.vroom
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ services:
   - xvfb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
-  - vroom $VROOM_ARGS --crawl --skip=vroom/system-vimjob.vroom
+  - vroom $VROOM_ARGS --crawl
 matrix:
   fast_finish: true
   allow_failures:

--- a/autoload/maktaba/syscall/neovim.vim
+++ b/autoload/maktaba/syscall/neovim.vim
@@ -1,0 +1,47 @@
+" CallAsync implementation using neovim's job support.
+
+""
+" @private
+function! maktaba#syscall#neovim#CreateInvocation(syscall, invocation) abort
+  " We'll pass this entire invocation to jobstart, which will pass it to the
+  " on_exit callback.
+  return {
+      \ '_syscall': a:syscall,
+      \ '_invocation': a:invocation,
+      \ 'Start': function('maktaba#syscall#neovim#Start'),
+      \ 'stdout_buffered': 1,
+      \ 'stderr_buffered': 1,
+      \ 'on_exit': function('maktaba#syscall#neovim#HandleJobExit')}
+endfunction
+
+
+""
+" @private
+" @dict SyscallNeovimInvocation
+" Dispatches syscall through |jobstart()|, and invokes the invocation's
+" callback once the command completes, passing in stdout, stderr and exit code
+" to it.
+" The neovim |job_control| implementation for @function(#CallAsync).
+function! maktaba#syscall#neovim#Start() abort dict
+  let self._job = jobstart(self._syscall.GetCommand(), self)
+  " Send stdin immediately and close. Streaming input to stdin not supported.
+  if has_key(self._syscall, 'stdin')
+    call chansend(self._job, self._syscall.stdin)
+  endif
+  call chanclose(self._job, 'stdin')
+endfunction
+
+
+""
+" @private
+" @dict SyscallNeovimInvocation
+function! maktaba#syscall#neovim#HandleJobExit(
+      \ unused_job,
+      \ status,
+      \ unused_event) abort dict
+  " jobcontrol sets stdout and stderr when no callbacks are given.
+  call self._invocation.Finish({
+      \ 'status': a:status,
+      \ 'stdout': join(self.stdout, "\n"),
+      \ 'stderr': join(self.stderr, "\n")})
+endfunction

--- a/doc/maktaba.txt
+++ b/doc/maktaba.txt
@@ -551,12 +551,13 @@ Syscall.CallAsync({callback}, {allow_sync_fallback})     *Syscall.CallAsync()*
   where env_dict contains tab, buffer, path, column and line info. This
   fallback will be deprecated and stop working in future versions of maktaba.
 
-  Asynchronous calls are executed via vim's |job| support. If the vim instance
-  is missing job support, this will try to fall back to legacy |clientserver|
-  invocation, which has a few preconditions of its own (see below). If neither
-  option is available, asynchronous calls are not possible, and the call will
-  either throw |ERROR(MissingFeature)| or fall back to synchronous calls,
-  depending on the {allow_sync_fallback} parameter.
+  Asynchronous calls are executed via vim's |job| support.  For nvim, they are
+  executed using |job_control|.  If the vim instance is missing job support,
+  this will try to fall back to legacy |clientserver| invocation, which has a
+  few preconditions of its own (see below). If neither option is available,
+  asynchronous calls are not possible, and the call will either throw
+  |ERROR(MissingFeature)| or fall back to synchronous calls, depending on the
+  {allow_sync_fallback} parameter.
 
   The legacy fallback executes calls via |--remote-expr| using vim's
   |clientserver| capabilities, so the preconditions for it are vim being

--- a/vroom/system-job.vroom
+++ b/vroom/system-job.vroom
@@ -1,6 +1,11 @@
 In addition to the functionality featured in system.vroom, the maktaba#syscall#
 helpers feature asynchronous execution powered by vim's native jobs feature.
 
+Note that we use delays of 0.1s on the asynchronous calls to ensure nvim has
+enough time to flush the contents of stdout to vroom.  This shouldn't be
+necessary for non-test usage.
+(See https://github.com/google/vim-maktaba/pull/234 for more details.)
+
 First, we need to work around for nvim prompting users to press enter.
 (See https://github.com/google/vim-codefmt/pull/131)
 

--- a/vroom/system-job.vroom
+++ b/vroom/system-job.vroom
@@ -47,9 +47,9 @@ To execute system calls asynchronously, use CallAsync.
   :function Callback(result) abort<CR>
   |  let g:callback_stdout = a:result.stdout<CR>
   |endfunction
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.2s)
   ! echo hi
-  :echomsg g:callback_stdout (0.1s)
+  :echomsg g:callback_stdout
   ~ hi
   :echomsg g:invocation.stdout
   ~ hi
@@ -58,7 +58,7 @@ It is also possible to force synchronous execution.
 
   :call maktaba#syscall#SetAsyncDisabledForTesting(1)
   :call maktaba#syscall#ForceSyncFallbackAllowedForTesting(1)
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.2s)
   ! echo hi.*
 
   :call maktaba#syscall#SetAsyncDisabledForTesting(0)
@@ -67,21 +67,21 @@ It is also possible to force synchronous execution.
 Asynchronous calls can also take a stdin parameter.
 
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.2s)
   ! cat
-  :echomsg g:invocation.stdout (0.1s)
+  :echomsg g:invocation.stdout
   ~ Hello
 
 And() and Or() can also be used to chain Asynchronous commands.
 
   :let g:syscall = maktaba#syscall#Create('true').And('echo SUCCESS')
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.2s)
   ! true && echo SUCCESS
-  :echomsg g:invocation.stdout (0.1s)
+  :echomsg g:invocation.stdout
   ~ SUCCESS
 
   :let g:syscall = maktaba#syscall#Create('false').And('echo FAILURE')
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.2s)
   ! false && echo FAILURE
-  :echomsg g:invocation.stdout (0.1s)
+  :echomsg g:invocation.stdout
   ~ FAILURE

--- a/vroom/system-job.vroom
+++ b/vroom/system-job.vroom
@@ -23,7 +23,7 @@ vim jobs.
 
   :if !has('job') && !has('nvim')<CR>
   |  echomsg maktaba#error#MissingFeature(
-  |      'Must have +job support to run system-vimjob.vroom examples')<CR>
+  |      'Must have +job support or nvim to run system-job.vroom examples')<CR>
   |endif
 
 
@@ -42,9 +42,9 @@ To execute system calls asynchronously, use CallAsync.
   :function Callback(result) abort<CR>
   |  let g:callback_stdout = a:result.stdout<CR>
   |endfunction
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
   ! echo hi
-  :echomsg g:callback_stdout
+  :echomsg g:callback_stdout (0.1s)
   ~ hi
   :echomsg g:invocation.stdout
   ~ hi
@@ -53,7 +53,7 @@ It is also possible to force synchronous execution.
 
   :call maktaba#syscall#SetAsyncDisabledForTesting(1)
   :call maktaba#syscall#ForceSyncFallbackAllowedForTesting(1)
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
   ! echo hi.*
 
   :call maktaba#syscall#SetAsyncDisabledForTesting(0)
@@ -62,21 +62,21 @@ It is also possible to force synchronous execution.
 Asynchronous calls can also take a stdin parameter.
 
   :let g:syscall = maktaba#syscall#Create(['cat']).WithStdin("Hello")
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
   ! cat
-  :echomsg g:invocation.stdout
+  :echomsg g:invocation.stdout (0.1s)
   ~ Hello
 
 And() and Or() can also be used to chain Asynchronous commands.
 
   :let g:syscall = maktaba#syscall#Create('true').And('echo SUCCESS')
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
   ! true && echo SUCCESS
-  :echomsg g:invocation.stdout
+  :echomsg g:invocation.stdout (0.1s)
   ~ SUCCESS
 
   :let g:syscall = maktaba#syscall#Create('false').And('echo FAILURE')
-  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)
+  :let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2) (0.1s)
   ! false && echo FAILURE
-  :echomsg g:invocation.stdout
+  :echomsg g:invocation.stdout (0.1s)
   ~ FAILURE

--- a/vroom/system-vimjob.vroom
+++ b/vroom/system-vimjob.vroom
@@ -1,6 +1,13 @@
 In addition to the functionality featured in system.vroom, the maktaba#syscall#
 helpers feature asynchronous execution powered by vim's native jobs feature.
 
+First, we need to work around for nvim prompting users to press enter.
+(See https://github.com/google/vim-codefmt/pull/131)
+
+  :if has('nvim')<CR>
+  |  set cmdheight=30<CR>
+  |endif<CR>
+
 Before we dive in, let's get maktaba installed and set up the shell override:
 
   @system (STRICT)
@@ -14,7 +21,7 @@ Before we dive in, let's get maktaba installed and set up the shell override:
 The examples featured in this file only work with vim instances that support
 vim jobs.
 
-  :if !has('job')<CR>
+  :if !has('job') && !has('nvim')<CR>
   |  echomsg maktaba#error#MissingFeature(
   |      'Must have +job support to run system-vimjob.vroom examples')<CR>
   |endif


### PR DESCRIPTION
Hello!

I think I've managed to get support for neovim's jobcontrol (#125) working (I've tested it manually with [vim-coverage](https://github.com/google/vim-coverage), which wasn't working for me and caused me to try and solve this in the first place).

However, in order to get system-vimjob.vroom to succeed, I need to pass vroom `--shell-delay .25` (by default vim's delay is 0.25 and neovim's is 0.0).  Here's an example failure:

```
└─ $ vroom --neovim vroom/system-vimjob.vroom
vroom/system-vimjob.vroom
FAILED on line 45: Multiple failures:
Expected system call not received.

Got no chance to inject response:
 EXPECT:        echo hi (regex mode)

Failed command on line 45:
:let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)

Queued system controls are:
 EXPECT:        echo hi (regex mode)

No system calls received. Perhaps your --shell is broken?

Last few commands (most recent last) were:
:if has('nvim')<CR>  set cmdheight=30<CR>endif<CR><CR>
:set nocompatible<CR>
:let g:maktabadir = fnamemodify($VROOMFILE, ':p:h:h')<CR>
:let g:bootstrapfile = g:maktabadir . '/bootstrap.vim'<CR>
:execute 'source' g:bootstrapfile<CR>
:call maktaba#system#SetUsableShellRegex('\v<shell\.vroomfaker$')<CR>
:if !has('job') && !has('nvim')<CR>  echomsg maktaba#error#MissingFeature(      'Must have +job support to run system-vimjob.vroom examples')<CR>endif<CR>
:function AsyncWait(invocation, delay) abort<CR>  let l:deadline = localtime() + a:delay " wait for at most N seconds<CR>  while !a:invocation.finished && localtime() < l:deadline<CR>    sleep 100m<CR>  endwhile<CR>  call maktaba#ensure#IsTrue(a:invocation.finished, 'Async callback was expected to complete within %d seconds', a:delay)<CR>  return a:invocation<CR>endfunction<CR>
:let g:syscall = maktaba#syscall#Create(['echo', 'hi'])<CR>
:function Callback(result) abort<CR>  let g:callback_stdout = a:result.stdout<CR>endfunction<CR>
:let g:invocation = AsyncWait(g:syscall.CallAsync('Callback', 0), 2)<CR>

Ran 1 test in vroom/system-vimjob.vroom. 0 passing, 0 errored, 1 failed.
```

Again, this works fine:

```
└─ $ vroom --neovim vroom/system-vimjob.vroom --shell-delay .25
vroom/system-vimjob.vroom
Ran 1 test in vroom/system-vimjob.vroom. 1 passing, 0 errored, 0 failed.
```

Any ideas on whether this is an actual problem in my use of `jobcontrol`, or if the async delay is just necessary for nvim in this case?  I've looked into it for a bit, but this is my first adventure in maktaba/vroom.