### PR TITLE
Replace "whitelist" with more inclusive terminology

### DIFF
--- a/autoload/maktaba/flags.vim
+++ b/autoload/maktaba/flags.vim
@@ -5,9 +5,9 @@
 " list) are not sourced until after .vimrc files. Thus, users may only set list
 " and dict settings, they may not easily add to or remove from default settings.
 "
-" For example, suppose a plugin provides a whitelist which you would like to
-" alter. You can set the whitelist in your vimrc, but you cannot add to it:
-" the whitelist doesn't exist until plugin-time, after the vimrc exits.
+" For example, suppose a plugin provides an allowlist which you would like to
+" alter. You can set the allowlist in your vimrc, but you cannot add to it:
+" the allowlist doesn't exist until plugin-time, after the vimrc exits.
 "
 " The solution is flags. Each Maktaba plugin which uses |maktaba#plugin#Enter|
 " has a plugin dictionary, which has a flag dictionary containing Flag objects,

--- a/autoload/maktaba/syscall.vim
+++ b/autoload/maktaba/syscall.vim
@@ -56,7 +56,7 @@ function! s:DoSyscallCommon(syscall, CallFunc, throw_errors) abort
   let l:return_data = {}
 
   " Force shell to /bin/sh since vim only works properly with POSIX shells.
-  " If the shell is a whitelisted wrapper, override the wrapped shell via $SHELL
+  " If the shell is an allowed wrapper, override the wrapped shell via $SHELL
   " instead.
   let l:shell_state = maktaba#value#SaveAll(['&shell', '$SHELL'])
   if &shell !~# s:usable_shell


### PR DESCRIPTION
No change to logic. This prefers "allowlist" to "whitelist" for the sake
of using inclusive terminology.