### PR TITLE
Avoid setting global nomodifiable in selector help

### DIFF
--- a/autoload/maktaba/ui/selector.vim
+++ b/autoload/maktaba/ui/selector.vim
@@ -362,8 +362,8 @@ function! maktaba#ui#selector#DoToggleHelp() dict abort
   let l:len_help = len(self._GetHelpLines())
   let self._is_verbose = !self._is_verbose
   call maktaba#buffer#Overwrite(1, l:len_help, self._GetHelpLines())
-  let &readonly = l:prev_read
-  let &modifiable = l:prev_mod
+  let &l:readonly = l:prev_read
+  let &l:modifiable = l:prev_mod
 endfunction
 
 

--- a/autoload/maktaba/ui/selector.vim
+++ b/autoload/maktaba/ui/selector.vim
@@ -355,15 +355,13 @@ endfunction
 " Toggle whether verbose help is shown for the selector.
 function! maktaba#ui#selector#DoToggleHelp() dict abort
   " TODO(dbarnett): Don't modify buffer if none exists.
-  let l:prev_read = &readonly
-  let l:prev_mod = &modifiable
   setlocal noreadonly
   setlocal modifiable
   let l:len_help = len(self._GetHelpLines())
   let self._is_verbose = !self._is_verbose
   call maktaba#buffer#Overwrite(1, l:len_help, self._GetHelpLines())
-  let &l:readonly = l:prev_read
-  let &l:modifiable = l:prev_mod
+  setlocal readonly
+  setlocal nomodifiable
 endfunction
 
 


### PR DESCRIPTION
## problem

Using the help menu `H` in selector window sets global nomodifiable and readonly options.
Files opened from the selector menu are then locked for editing.

## solution

Restore nomodifiable and readonly options locally so they only apply to the selector window.